### PR TITLE
fix(transport): add payload size limits to prevent OOM attacks

### DIFF
--- a/internal/transport/errors.go
+++ b/internal/transport/errors.go
@@ -2,13 +2,18 @@ package transport
 
 import "errors"
 
+// MaxPayloadLen is the maximum allowed payload size for received transport
+// packets. Packets exceeding this size are rejected to prevent OOM attacks.
+const MaxPayloadLen = 16 * 1024 * 1024
+
 // Transport-level protocol errors.
 //
 // These errors indicate data integrity or protocol compatibility issues at
 // the transport layer (TCP, obfuscated TCP, etc.).
 var (
-	// ErrPayloadTooLarge is returned when attempting to send a message that
-	// exceeds the maximum payload size for the configured transport.
+	// ErrPayloadTooLarge is returned when attempting to send or receive a
+	// message that exceeds the maximum payload size for the configured
+	// transport.
 	ErrPayloadTooLarge = errors.New("transport: payload exceeds maximum size")
 	// ErrCRC32Mismatch is returned when the CRC32 checksum of a received
 	// TCP packet does not match the expected value, indicating data

--- a/internal/transport/tcp_abridged.go
+++ b/internal/transport/tcp_abridged.go
@@ -73,6 +73,9 @@ func (t *TCPAbridged) Recv() ([]byte, error) {
 	}
 
 	length *= 4
+	if length > MaxPayloadLen {
+		return nil, ErrPayloadTooLarge
+	}
 	if cap(t.readBuf) < length {
 		t.readBuf = make([]byte, length)
 	}

--- a/internal/transport/tcp_full.go
+++ b/internal/transport/tcp_full.go
@@ -57,6 +57,9 @@ func (t *TCPFull) Recv() ([]byte, error) {
 	if packetLen < 12 {
 		return nil, fmt.Errorf("tcp_full: packet too short: %d", packetLen)
 	}
+	if packetLen-4 > uint32(MaxPayloadLen) {
+		return nil, ErrPayloadTooLarge
+	}
 
 	rest := make([]byte, packetLen-4)
 	if _, err := io.ReadFull(t.conn, rest); err != nil {

--- a/internal/transport/tcp_obfuscated.go
+++ b/internal/transport/tcp_obfuscated.go
@@ -203,6 +203,9 @@ func (t *TCPObfuscated) Recv() ([]byte, error) {
 		decLen := t.dec.Process(lenBytes[:])
 		length := binary.LittleEndian.Uint32(decLen)
 
+		if length > uint32(MaxPayloadLen) {
+			return nil, ErrPayloadTooLarge
+		}
 		if cap(t.readBuf) < int(length) {
 			t.readBuf = make([]byte, length)
 		}
@@ -232,6 +235,9 @@ func (t *TCPObfuscated) Recv() ([]byte, error) {
 		}
 
 		length *= 4
+		if length > MaxPayloadLen {
+			return nil, ErrPayloadTooLarge
+		}
 		if cap(t.readBuf) < length {
 			t.readBuf = make([]byte, length)
 		}

--- a/internal/transport/ws_stdlib.go
+++ b/internal/transport/ws_stdlib.go
@@ -151,7 +151,7 @@ func (c *wsConn) readFrame() (op byte, payload []byte, err error) {
 		length = int64(binary.BigEndian.Uint64(b[:]))
 	}
 
-	if length < 0 || length > 1<<30 {
+	if length < 0 || length > int64(MaxPayloadLen) {
 		return 0, nil, fmt.Errorf("ws: frame too large: %d", length)
 	}
 


### PR DESCRIPTION
## Summary

Security fix for **Critical OOM vulnerabilities** (DREAD 8.2 each) in all TCP transport `Recv()` paths.

## Problem

All transport implementations allocated receive buffers based on untrusted length fields from the wire without upper-bound validation:

- **`tcp_full.go`**: `packetLen` up to 4 GB allocation
- **`tcp_abridged.go`**: length up to 64 MB allocation  
- **`tcp_obfuscated.go`**: decrypted length up to 4 GB allocation
- **`ws_stdlib.go`**: WebSocket frame limit was 1 GiB

A malicious server, MITM attacker, or compromised peer could send a crafted length field causing the client to attempt a multi-gigabyte allocation, crashing with OOM.

## Fix

- Added `MaxPayloadLen = 16 MiB` constant to `transport/errors.go`
- All `Recv()` paths now check payload size before `make([]byte, length)` and return `ErrPayloadTooLarge` if exceeded
- WebSocket frame limit reduced from 1 GiB to 16 MiB (matching `MaxPayloadLen`)
- No behavioral change for legitimate traffic (MTProto packets are typically well under 1 MiB)

## Test Plan

- [x] `go build ./internal/transport/...` — compiles clean
- [x] `go test ./internal/transport/...` — all tests pass
- [ ] Existing integration tests should pass (no functional change for normal traffic)