### PR TITLE
fix(download): sanitize filenames to prevent path traversal

### DIFF
--- a/telegram/download.go
+++ b/telegram/download.go
@@ -688,7 +688,7 @@ func guessExtension(mimeType string) string {
 }
 
 func buildDownloadPath(dir string, info *downloadInput) (string, error) {
-	fileName := info.fileName
+	fileName := sanitizeFileName(info.fileName)
 
 	if fileName == "" {
 		ext := guessExtension(info.mimeType)
@@ -714,6 +714,18 @@ func buildDownloadPath(dir string, info *downloadInput) (string, error) {
 		}
 	}
 	return dir, nil
+}
+
+func sanitizeFileName(name string) string {
+	if name == "" {
+		return ""
+	}
+	name = filepath.Base(name)
+	cleaned := strings.ReplaceAll(name, "..", "")
+	if cleaned == "" || cleaned == "." || cleaned == "/" {
+		return ""
+	}
+	return cleaned
 }
 
 func (c *Client) downloadToPath(ctx context.Context, input interface{}, filePath string, progress params.ProgressFunc) (string, error) {

--- a/telegram/download_test.go
+++ b/telegram/download_test.go
@@ -420,3 +420,32 @@ func TestIsFileReferenceError(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeFileName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"normal", "photo.jpg", "photo.jpg"},
+		{"empty", "", ""},
+		{"path traversal", "../../etc/passwd", "passwd"},
+		{"absolute unix", "/etc/shadow", "shadow"},
+		{"absolute windows", "C:\\Windows\\System32\\config", "C:\\Windows\\System32\\config"},
+		{"double dot only", "..", ""},
+		{"dot only", ".", ""},
+		{"slash only", "/", ""},
+		{"nested traversal", "foo/bar/../../baz", "baz"},
+		{"dotdot in name", "file..name.txt", "filename.txt"},
+		{"null bytes", "file\x00name.txt", "file\x00name.txt"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFileName(tt.in)
+			if got != tt.want {
+				t.Errorf("sanitizeFileName(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Security fix for **High path traversal vulnerability** (DREAD 7.2) in download filename handling.

## Problem

`buildDownloadPath` used `info.fileName` — sourced from `DocumentMedia.FileName` in Telegram message metadata — directly in `filepath.Join`. A malicious Telegram document with `FileName: "../../etc/passwd"` would write outside the intended download directory.

```go
// Before: attacker-controlled filename passed directly
return filepath.Join(dir, fileName), nil
```

## Fix

Added `sanitizeFileName()` which:
1. Strips directory components via `filepath.Base()` (resolves `../../etc/passwd` → `passwd`)
2. Removes `..` sequences from the remaining name
3. Rejects empty, dot-only, or slash-only results (falls back to auto-generated name)

Also includes unit tests covering path traversal, absolute paths, nested traversal, and edge cases.

## Test Plan

- [x] `go build ./telegram/...` — compiles clean
- [x] `go test ./telegram/... -run TestSanitizeFileName -v` — all cases pass
- [x] `go test ./telegram/... -run TestDownload` — existing download tests pass