### PR TITLE
fix(crypto): replace math/rand, add DH prime validation, constant-time compare

### DIFF
--- a/internal/crypto/mtproto.go
+++ b/internal/crypto/mtproto.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"fmt"
 	"sync"
 
@@ -169,7 +170,7 @@ func Unpack(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTProtoMessa
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "data too short"}
 	}
 
-	if !bytes.Equal(data[:8], authKeyID) {
+	if subtle.ConstantTimeCompare(data[:8], authKeyID) != 1 {
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "b.read(8) == auth_key_id"}
 	}
 
@@ -193,11 +194,11 @@ func Unpack(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTProtoMessa
 	hc.Write(decrypted)
 	var msgKeyCheck [32]byte
 	hc.Sum(msgKeyCheck[:0])
-	if !bytes.Equal(msgKey, msgKeyCheck[8:24]) {
+	if subtle.ConstantTimeCompare(msgKey, msgKeyCheck[8:24]) != 1 {
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "msg_key == sha256(auth_key[96:128] + data)[8:24]"}
 	}
 
-	if !bytes.Equal(decrypted[8:16], sessionID) {
+	if subtle.ConstantTimeCompare(decrypted[8:16], sessionID) != 1 {
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "data.read(8) == session_id"}
 	}
 
@@ -234,7 +235,7 @@ func UnpackEnvelope(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTPr
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "data too short"}
 	}
 
-	if !bytes.Equal(data[:8], authKeyID) {
+	if subtle.ConstantTimeCompare(data[:8], authKeyID) != 1 {
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "b.read(8) == auth_key_id"}
 	}
 
@@ -259,12 +260,12 @@ func UnpackEnvelope(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTPr
 	hc.Write(decrypted)
 	var msgKeyCheck [32]byte
 	hc.Sum(msgKeyCheck[:0])
-	if !bytes.Equal(msgKey, msgKeyCheck[8:24]) {
+	if subtle.ConstantTimeCompare(msgKey, msgKeyCheck[8:24]) != 1 {
 		ReleaseAESBuf(decrypted)
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "msg_key check failed"}
 	}
 
-	if !bytes.Equal(decrypted[8:16], sessionID) {
+	if subtle.ConstantTimeCompare(decrypted[8:16], sessionID) != 1 {
 		ReleaseAESBuf(decrypted)
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "session_id mismatch"}
 	}

--- a/internal/crypto/prime.go
+++ b/internal/crypto/prime.go
@@ -1,9 +1,8 @@
 package crypto
 
 import (
+	"crypto/rand"
 	"math/big"
-	"math/rand"
-	"time"
 )
 
 // CurrentDHPrime is the 2048-bit safe prime used for Diffie-Hellman key exchange
@@ -50,17 +49,24 @@ func Decompose(pq int64) int64 {
 	}
 
 	n := big.NewInt(pq)
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	nMinus1 := new(big.Int).Sub(n, big.NewInt(1))
 	tmp := new(big.Int)
 	bigOne := big.NewInt(1)
 
 	for attempt := 0; attempt < 64; attempt++ {
-		c := new(big.Int).Add(new(big.Int).Rand(rng, nMinus1), bigOne)
+		c, err := rand.Int(rand.Reader, nMinus1)
+		if err != nil {
+			continue
+		}
+		c.Add(c, bigOne)
 		if c.Cmp(bigOne) == 0 {
 			c.SetInt64(2)
 		}
-		y := new(big.Int).Add(new(big.Int).Rand(rng, nMinus1), bigOne)
+		y, err := rand.Int(rand.Reader, nMinus1)
+		if err != nil {
+			continue
+		}
+		y.Add(y, bigOne)
 		g := big.NewInt(1)
 		q := big.NewInt(1)
 		r := int64(1)

--- a/telegram/secret.go
+++ b/telegram/secret.go
@@ -45,6 +45,12 @@ func (c *Client) RequestSecretChat(ctx context.Context, userID tg.InputUserClass
 		dhPrime = new(big.Int).SetBytes(cfg.P)
 		g = cfg.G
 		dhVersion = cfg.Version
+		if dhPrime.BitLen() < 2048 || !dhPrime.ProbablyPrime(20) {
+			return nil, fmt.Errorf("telegram: server sent invalid DH prime")
+		}
+		if g < 2 || g > 7 {
+			return nil, fmt.Errorf("telegram: invalid DH generator: %d", g)
+		}
 	case *tg.MessagesDHConfigNotModified:
 		dhPrime = crypto.CurrentDHPrime
 		g = 2
@@ -127,6 +133,12 @@ func (c *Client) AcceptSecretChat(ctx context.Context, chatID int32) (*SecretCha
 		chat.DHPrime = new(big.Int).SetBytes(cfg.P)
 		chat.G = cfg.G
 		chat.DHConfigVersion = cfg.Version
+		if chat.DHPrime.BitLen() < 2048 || !chat.DHPrime.ProbablyPrime(20) {
+			return nil, fmt.Errorf("telegram: server sent invalid DH prime")
+		}
+		if chat.G < 2 || chat.G > 7 {
+			return nil, fmt.Errorf("telegram: invalid DH generator: %d", chat.G)
+		}
 	case *tg.MessagesDHConfigNotModified:
 	}
 


### PR DESCRIPTION
## Summary

Security hardening for three crypto-related issues (DREAD 7.2–7.6).

## Changes

### 1. Replace `math/rand` with `crypto/rand` in `prime.go`
`Decompose` (Pollard's rho factorization during DH key exchange) used `math/rand` seeded with `time.Now().UnixNano()`. While factorization results are self-verifying, this violated the principle that no function in a crypto package should use a predictable PRNG. Now uses `crypto/rand.Int`.

### 2. Validate server-provided DH parameters in secret chat
`RequestSecretChat` and `AcceptSecretChat` accepted server-provided `dhPrime` and `g` without validation. A MITM or compromised server could inject a weak DH prime enabling passive decryption. Now validates:
- `dhPrime.BitLen() >= 2048`
- `dhPrime.ProbablyPrime(20)`
- `g` is in range `[2, 7]`

### 3. Constant-time comparison for MAC/key/session checks
Replaced `bytes.Equal` with `subtle.ConstantTimeCompare` for all security-sensitive comparisons in `Unpack` and `UnpackEnvelope`:
- `auth_key_id` check
- `msg_key` integrity check (SHA-256 based MAC)
- `session_id` check

Prevents timing side-channels that could leak auth key or plaintext information.

## Test Plan

- [x] `go test ./internal/crypto/...` — all pass
- [x] `go test ./telegram/...` — all pass
- [x] `go build ./internal/crypto/... ./telegram/...` — compiles clean