### PR TITLE
fix(auth): validate DH params (dh_prime, g_a range, server_nonce) in key exchange

### DIFF
--- a/internal/session/auth.go
+++ b/internal/session/auth.go
@@ -232,12 +232,42 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 			return nil, ErrDHNonceMismatch
 		}
 
-		b := a.generateRandomBN(2048)
+		if dhInner.ServerNonce != resPQ.ServerNonce {
+			return nil, ErrServerNonceMismatch
+		}
+
+		if v.ServerNonce != resPQ.ServerNonce {
+			return nil, ErrServerNonceMismatch
+		}
+
 		dhPrime := new(big.Int).SetBytes([]byte(dhInner.DHPrime))
+		if dhPrime.BitLen() != 2048 {
+			return nil, fmt.Errorf("%w: bit length %d", ErrDHPrimeInvalid, dhPrime.BitLen())
+		}
+		if !dhPrime.ProbablyPrime(20) {
+			return nil, ErrDHPrimeInvalid
+		}
+
 		g := big.NewInt(int64(dhInner.G))
-		gB := new(big.Int).Exp(g, b, dhPrime)
+		if g.Int64() < 2 || g.Int64() > 7 {
+			return nil, fmt.Errorf("session: invalid DH generator %d", g.Int64())
+		}
 
 		gA := new(big.Int).SetBytes([]byte(dhInner.GA))
+		one := big.NewInt(1)
+		if gA.Cmp(one) <= 0 || gA.Cmp(new(big.Int).Sub(dhPrime, one)) >= 0 {
+			return nil, ErrGAOutOfRange
+		}
+
+		lowerBound := new(big.Int).Lsh(big.NewInt(1), 2048-64)
+		upperBound := new(big.Int).Sub(dhPrime, new(big.Int).Lsh(big.NewInt(1), 2048-64))
+		if gA.Cmp(lowerBound) < 0 || gA.Cmp(upperBound) > 0 {
+			return nil, ErrGAOutOfRange
+		}
+
+		b := a.generateRandomBN(2048)
+		gB := new(big.Int).Exp(g, b, dhPrime)
+
 		authKey := computeAuthKey(gA, b, dhPrime)
 
 		clientDHInner := &tg.ClientDHInnerData{
@@ -278,6 +308,13 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 
 		switch v := obj.(type) {
 		case *tg.DHGenOk:
+			if v.Nonce != nonce {
+				return nil, ErrNonceMismatch
+			}
+			if v.ServerNonce != resPQ.ServerNonce {
+				return nil, ErrServerNonceMismatch
+			}
+
 			expectedHash := computeNewNonceHash1(newNonce[:], authKey)
 			if !bytes.Equal(v.NewNonceHash1[:], expectedHash) {
 				return nil, ErrNewNonceHashMismatch

--- a/internal/session/errors.go
+++ b/internal/session/errors.go
@@ -45,4 +45,14 @@ var (
 	// ErrDHGenFail is returned during key exchange step 10 when the server
 	// responds with dh_gen_fail, indicating the DH key generation failed.
 	ErrDHGenFail = errors.New("step 10: dh_gen_fail")
+
+	// ErrServerNonceMismatch is returned during the DH key exchange when
+	// the server_nonce in a server response does not match the original.
+	ErrServerNonceMismatch = errors.New("session: server_nonce mismatch")
+	// ErrDHPrimeInvalid is returned when the server's dh_prime fails
+	// validation (wrong bit length or not prime).
+	ErrDHPrimeInvalid = errors.New("session: dh_prime validation failed")
+	// ErrGAOutOfRange is returned when the server's g_a falls outside the
+	// required range [2, dh_prime-2].
+	ErrGAOutOfRange = errors.New("session: g_a out of range")
 )


### PR DESCRIPTION
## Summary

Critical DH parameter validation in the MTProto authorization key exchange, per the [Security Guidelines](https://core.telegram.org/mtproto/security_guidelines).

## Changes

### 1. dh_prime validation (`auth.go`)
- Verify `dh_prime` is exactly 2048 bits (`BitLen() == 2048`)
- Verify primality with 20 rounds of Miller-Rabin (`ProbablyPrime(20)`)
- Reject invalid primes before computing the shared key

### 2. g_a range check (`auth.go`)
- Verify `1 < g_a < dh_prime - 1` (spec minimum)
- Verify `2^1984 < g_a < dh_prime - 2^1984` (recommended range)
- Prevents a malicious server from sending g_a = 0, 1, or dh_prime-1 which would produce a predictable auth_key

### 3. Generator g validation
- Verify `2 <= g <= 7` as per spec

### 4. server_nonce validation
- Added `server_nonce` checks in `ServerDHParamsOk`, `ServerDHInnerData`, and `DHGenOk` responses
- Previously only `nonce` was checked; `server_nonce` was never validated

### New sentinel errors
- `ErrServerNonceMismatch`
- `ErrDHPrimeInvalid`
- `ErrGAOutOfRange`

## Test Plan
- [x] `go build ./internal/session/...` — compiles clean
- [x] `go test ./internal/session/...` — all pass