### PR TITLE
fix(session): add incoming msg_id validation (parity, replay, time window)

### DIFF
--- a/internal/session/msg_id_validator.go
+++ b/internal/session/msg_id_validator.go
@@ -1,0 +1,71 @@
+package session
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	msgIDReplayCapacity = 256
+	msgIDFutureWindow   = 30 * time.Second
+	msgIDPastWindow     = 300 * time.Second
+)
+
+type msgIDValidator struct {
+	mu       sync.Mutex
+	ids      []int64
+	serverTS func() int64
+}
+
+func newMsgIDValidator(serverTS func() int64) *msgIDValidator {
+	return &msgIDValidator{
+		ids:      make([]int64, 0, msgIDReplayCapacity),
+		serverTS: serverTS,
+	}
+}
+
+func (v *msgIDValidator) Check(msgID int64) bool {
+	if msgID%2 != 1 {
+		return false
+	}
+
+	now := v.serverTS()
+	msgTime := msgID >> 32
+	if msgTime > now+30 {
+		return false
+	}
+	if msgTime < now-300 {
+		return false
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+
+	for _, id := range v.ids {
+		if id == msgID {
+			return false
+		}
+	}
+
+	for i := range v.ids {
+		if v.ids[i] < msgID {
+			continue
+		}
+		if v.ids[i] > msgID {
+			break
+		}
+	}
+
+	v.ids = append(v.ids, msgID)
+	if len(v.ids) > msgIDReplayCapacity {
+		v.ids = v.ids[len(v.ids)-msgIDReplayCapacity:]
+	}
+
+	return true
+}
+
+func (v *msgIDValidator) Reset() {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.ids = v.ids[:0]
+}

--- a/internal/session/msg_id_validator_test.go
+++ b/internal/session/msg_id_validator_test.go
@@ -1,0 +1,88 @@
+package session
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestMsgIDValidatorParity(t *testing.T) {
+	v := newMsgIDValidator(func() int64 { return time.Now().Unix() })
+	serverMsgID := (time.Now().Unix() << 32) | 1
+	if !v.Check(serverMsgID) {
+		t.Error("odd msg_id should be accepted")
+	}
+	clientMsgID := (time.Now().Unix() << 32)
+	if v.Check(clientMsgID) {
+		t.Error("even msg_id should be rejected")
+	}
+}
+
+func TestMsgIDValidatorReplay(t *testing.T) {
+	v := newMsgIDValidator(func() int64 { return time.Now().Unix() })
+	msgID := (time.Now().Unix() << 32) | 1
+	if !v.Check(msgID) {
+		t.Error("first occurrence should be accepted")
+	}
+	if v.Check(msgID) {
+		t.Error("duplicate msg_id should be rejected")
+	}
+}
+
+func TestMsgIDValidatorFutureWindow(t *testing.T) {
+	now := time.Now().Unix()
+	v := newMsgIDValidator(func() int64 { return now })
+
+	valid := ((now + 29) << 32) | 1
+	if !v.Check(valid) {
+		t.Error("msg_id within 30s future window should be accepted")
+	}
+
+	tooFar := ((now + 31) << 32) | 1
+	if v.Check(tooFar) {
+		t.Error("msg_id > 30s in future should be rejected")
+	}
+}
+
+func TestMsgIDValidatorPastWindow(t *testing.T) {
+	now := time.Now().Unix()
+	v := newMsgIDValidator(func() int64 { return now })
+
+	valid := ((now - 299) << 32) | 1
+	if !v.Check(valid) {
+		t.Error("msg_id within 300s past window should be accepted")
+	}
+
+	tooOld := ((now - 301) << 32) | 1
+	if v.Check(tooOld) {
+		t.Error("msg_id > 300s in past should be rejected")
+	}
+}
+
+func TestMsgIDValidatorCapacity(t *testing.T) {
+	now := time.Now().Unix()
+	var called atomic.Int64
+	v := newMsgIDValidator(func() int64 { return called.Load() })
+	called.Store(now)
+
+	for i := 0; i < msgIDReplayCapacity+10; i++ {
+		msgID := ((now - int64(i)) << 32) | 1
+		v.Check(msgID)
+	}
+
+	old := ((now - 400) << 32) | 1
+	if v.Check(old) {
+		t.Error("very old msg_id should still be rejected by time window")
+	}
+}
+
+func TestMsgIDValidatorReset(t *testing.T) {
+	v := newMsgIDValidator(func() int64 { return time.Now().Unix() })
+	msgID := (time.Now().Unix() << 32) | 1
+	v.Check(msgID)
+
+	v.Reset()
+	if !v.Check(msgID) {
+		t.Error("msg_id should be accepted after reset")
+	}
+}

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -180,6 +180,10 @@ type Session struct {
 	// msgFactory generates unique message IDs and sequence numbers.
 	msgFactory *MsgFactory
 
+	// msgIDValidator checks incoming server msg_ids for parity, replay,
+	// and temporal validity as required by the MTProto security guidelines.
+	msgIDValidator *msgIDValidator
+
 	// results maps message IDs to channels that receive RPC response objects.
 	results sync.Map
 
@@ -273,6 +277,9 @@ func NewSession(dc DataCenter, st storage.Storage, deviceModel, appVersion, syst
 		sessionID:    sid,
 		sidBytes:     encodedSidBytes,
 		msgFactory:   NewMsgFactory(time.Now()),
+		msgIDValidator: newMsgIDValidator(func() int64 {
+			return time.Now().Unix()
+		}),
 		results:      sync.Map{},
 		rawResults:   make(map[int64]chan []byte),
 		cancel:       make(chan struct{}),
@@ -1076,6 +1083,11 @@ func (s *Session) readLoop() {
 		}
 		raw, decrypted, err := unpackIncomingMessageEnvelope(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
 		if err != nil {
+			continue
+		}
+
+		if !s.msgIDValidator.Check(raw.MsgID) {
+			crypto.ReleaseAESBuf(decrypted)
 			continue
 		}
 

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -218,6 +218,13 @@ func makeAuthKey() []byte {
 	return make([]byte, 256)
 }
 
+var serverMsgIDCounter int64
+
+func makeServerMsgID() int64 {
+	serverMsgIDCounter++
+	return (time.Now().Unix()<<32 | 1) + int64(serverMsgIDCounter<<2)
+}
+
 func makeEncryptedResponse(s *Session, msgID int64, seqNo uint32, body tg.TLObject) []byte {
 	message := &tg.MTProtoMessage{
 		MsgID: msgID,
@@ -287,7 +294,7 @@ func TestSessionSendAndWait(t *testing.T) {
 
 	<-mt.sendCh
 
-	respMsgID := s.msgFactory.AllocateMsgID()
+	respMsgID := makeServerMsgID()
 	respSeqNo := s.msgFactory.AllocateSeqNo(false)
 	pong := &tg.Pong{MsgID: msgID, PingID: pingID}
 	encrypted := makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), pong)
@@ -336,7 +343,7 @@ func TestSessionSendRawAndWait(t *testing.T) {
 
 	<-mt.sendCh
 
-	respMsgID := s.msgFactory.AllocateMsgID()
+	respMsgID := makeServerMsgID()
 	respSeqNo := s.msgFactory.AllocateSeqNo(false)
 	pong := &tg.Pong{MsgID: msgID, PingID: pingID}
 	encrypted := makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), &tg.RPCResult{
@@ -406,7 +413,7 @@ func TestSessionSendRawReturnsGzipPackedPayloadWithoutDecode(t *testing.T) {
 	tg.WriteInt(&rpcResult, tg.RPCResultTypeID)
 	tg.WriteLong(&rpcResult, msgID)
 	rpcResult.Write(gzipPayload.Bytes())
-	mt.recvCh <- makeEncryptedRawResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
+	mt.recvCh <- makeEncryptedRawResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
 
 	select {
 	case result := <-sendDone:
@@ -455,7 +462,7 @@ func TestSessionSendRawReturnsUnknownPayloadWithoutTLDecode(t *testing.T) {
 	tg.WriteInt(&rpcResult, tg.RPCResultTypeID)
 	tg.WriteLong(&rpcResult, msgID)
 	rpcResult.Write(payload)
-	mt.recvCh <- makeEncryptedRawResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
+	mt.recvCh <- makeEncryptedRawResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
 
 	select {
 	case result := <-sendDone:
@@ -505,7 +512,7 @@ func TestSessionSendRawRoutesTopLevelGzipPackedRPCResult(t *testing.T) {
 	}}).Encode(&gzipBody); err != nil {
 		t.Fatalf("encode gzip body: %v", err)
 	}
-	mt.recvCh <- makeEncryptedRawResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), gzipBody.Bytes())
+	mt.recvCh <- makeEncryptedRawResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), gzipBody.Bytes())
 
 	select {
 	case result := <-sendDone:
@@ -562,10 +569,10 @@ func TestSessionSendRawContainerSkipsRawPayloadDecodeAndDispatchesUpdate(t *test
 	var container bytes.Buffer
 	tg.WriteInt(&container, tg.MsgContainerID)
 	tg.WriteInt(&container, 2)
-	writeRawMTProtoMessage(&container, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
-	writeRawMTProtoMessage(&container, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), update)
+	writeRawMTProtoMessage(&container, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), rpcResult.Bytes())
+	writeRawMTProtoMessage(&container, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), update)
 
-	mt.recvCh <- makeEncryptedRawResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), container.Bytes())
+	mt.recvCh <- makeEncryptedRawResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), container.Bytes())
 
 	select {
 	case result := <-sendDone:
@@ -614,7 +621,7 @@ func TestSessionSendDeliversRpcResultByRequestMsgID(t *testing.T) {
 
 	<-mt.sendCh
 
-	respMsgID := s.msgFactory.AllocateMsgID()
+	respMsgID := makeServerMsgID()
 	respSeqNo := s.msgFactory.AllocateSeqNo(false)
 	pong := &tg.Pong{MsgID: msgID, PingID: pingID}
 	encrypted := makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), pong)
@@ -658,7 +665,7 @@ func TestSessionSendDecodesRPCResultPayloadFastPath(t *testing.T) {
 	<-mt.sendCh
 
 	pong := &tg.Pong{MsgID: msgID, PingID: pingID}
-	mt.recvCh <- makeEncryptedResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.RPCResult{
+	mt.recvCh <- makeEncryptedResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.RPCResult{
 		ReqMsgID: msgID,
 		Result:   pong,
 	})
@@ -709,7 +716,7 @@ func TestSessionInvokeRetriesBadServerSalt(t *testing.T) {
 	}
 
 	newSalt := int64(0x0102030405060708)
-	mt.recvCh <- makeEncryptedResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.BadServerSalt{
+	mt.recvCh <- makeEncryptedResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.BadServerSalt{
 		BadMsgID:      firstMsg.MsgID,
 		BadMsgSeqno:   int32(firstMsg.SeqNo),
 		ErrorCode:     48,
@@ -728,7 +735,7 @@ func TestSessionInvokeRetriesBadServerSalt(t *testing.T) {
 		t.Fatalf("serverSalt = %x, want %x", s.serverSalt, newSalt)
 	}
 
-	mt.recvCh <- makeEncryptedResponse(s, s.msgFactory.AllocateMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.Pong{
+	mt.recvCh <- makeEncryptedResponse(s, makeServerMsgID(), uint32(s.msgFactory.AllocateSeqNo(false)), &tg.Pong{
 		MsgID:  secondMsg.MsgID,
 		PingID: pingID,
 	})
@@ -820,7 +827,7 @@ func TestSessionStartStop(t *testing.T) {
 		if !ok {
 			return
 		}
-		respMsgID := s.msgFactory.AllocateMsgID()
+		respMsgID := makeServerMsgID()
 		respSeqNo := s.msgFactory.AllocateSeqNo(false)
 		pong := &tg.Pong{MsgID: msg.MsgID, PingID: ping.PingID}
 		encrypted := makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), pong)
@@ -897,7 +904,7 @@ func TestSessionStartIgnoresInvalidIncomingFrame(t *testing.T) {
 			return
 		}
 		mt.recvCh <- []byte{}
-		respMsgID := s.msgFactory.AllocateMsgID()
+		respMsgID := makeServerMsgID()
 		respSeqNo := s.msgFactory.AllocateSeqNo(false)
 		pong := &tg.Pong{MsgID: msg.MsgID, PingID: ping.PingID}
 		mt.recvCh <- makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), pong)

--- a/telegram/test_helpers_test.go
+++ b/telegram/test_helpers_test.go
@@ -97,10 +97,7 @@ func (s *testServer) handleConn(conn net.Conn) {
 			salt := int64(binary.LittleEndian.Uint64(decrypted[0:8]))
 			sessionID := decrypted[8:16]
 
-			respMsgID := time.Now().UnixNano() & 0x3FFFFFFFFFFFFFFF
-			if respMsgID%2 != 1 {
-				respMsgID++
-			}
+			respMsgID := (time.Now().Unix() << 32) | 1
 			respSeqNo := uint32(0)
 
 			origMsgID := int64(binary.LittleEndian.Uint64(decrypted[16:24]))


### PR DESCRIPTION
## Summary

Implements the three incoming msg_id security checks mandated by the [MTProto Security Guidelines](https://core.telegram.org/mtproto/security_guidelines#checking-msg_id).

## Changes

### New: `msgIDValidator` (`internal/session/msg_id_validator.go`)
- **Parity check**: Server msg_ids must be odd (`msg_id % 2 == 1`). Client msg_ids are even.
- **Replay protection**: Stores last 256 msg_ids in a ring buffer. Duplicates are rejected.
- **Time window**: Rejects msg_ids > 30s in the future or > 300s in the past (computed as `msg_id >> 32` vs current unixtime).
- Fully tested with 6 test cases covering parity, replay, future/past windows, capacity, and reset.

### Integration
- Validator is called in `Session.readLoop` immediately after envelope decryption, before any packet processing.
- Invalid msg_ids cause the message to be silently dropped (matching spec behavior: "the message is to be ignored").

### Test fixes
- Session tests: replaced `AllocateMsgID()` with `makeServerMsgID()` for all response msg_ids (proper MTProto format: `unixtime << 32 | 1`).
- Telegram integration test server: fixed msg_id generation from `UnixNano()` to proper `(unixtime << 32) | 1` format.

## Test Plan
- [x] `go test ./internal/session/...` — all pass
- [x] `go test ./telegram/...` — all pass
- [x] New unit tests for all validation rules