### PR TITLE
fix(transport): obfuscated nonce protocol checks, max payload limits, transport errors

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1074,6 +1074,14 @@ func (s *Session) readLoop() {
 			}
 			continue
 		}
+		if len(data) == 4 {
+			code := int32(uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24)
+			if s.onDisconnect != nil {
+				s.onDisconnect(fmt.Errorf("transport error: code %d", -code))
+			}
+			return
+		}
+
 		raw, decrypted, err := unpackIncomingMessageEnvelope(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
 		if err != nil {
 			continue

--- a/internal/transport/tcp_abridged.go
+++ b/internal/transport/tcp_abridged.go
@@ -73,6 +73,9 @@ func (t *TCPAbridged) Recv() ([]byte, error) {
 	}
 
 	length *= 4
+	if length > maxPayloadLen {
+		return nil, ErrPayloadTooLarge
+	}
 	if cap(t.readBuf) < length {
 		t.readBuf = make([]byte, length)
 	}

--- a/internal/transport/tcp_full.go
+++ b/internal/transport/tcp_full.go
@@ -57,6 +57,9 @@ func (t *TCPFull) Recv() ([]byte, error) {
 	if packetLen < 12 {
 		return nil, fmt.Errorf("tcp_full: packet too short: %d", packetLen)
 	}
+	if packetLen-4 > maxPayloadLen {
+		return nil, ErrPayloadTooLarge
+	}
 
 	rest := make([]byte, packetLen-4)
 	if _, err := io.ReadFull(t.conn, rest); err != nil {

--- a/internal/transport/tcp_obfuscated.go
+++ b/internal/transport/tcp_obfuscated.go
@@ -11,6 +11,33 @@ import (
 	"github.com/mtgo-labs/mtgo/internal/crypto"
 )
 
+var forbiddenFirstInts = []uint32{
+	0xdddddddd,
+	0xeeeeeeee,
+	0x44414548,
+	0x54534f50,
+	0x20544547,
+	0x4954504f,
+	0x02010316,
+}
+
+func isForbiddenNonce(nonce []byte) bool {
+	if nonce[0] == 0xef {
+		return true
+	}
+	firstInt := binary.LittleEndian.Uint32(nonce[0:4])
+	for _, v := range forbiddenFirstInts {
+		if firstInt == v {
+			return true
+		}
+	}
+	secondInt := binary.LittleEndian.Uint32(nonce[4:8])
+	if secondInt == 0 {
+		return true
+	}
+	return false
+}
+
 // TCPObfuscated wraps an inner Transport with AES-CTR encryption to hide
 // the transport fingerprint from middleboxes. It negotiates encryption
 // keys via a random 64-byte nonce exchanged during Connect and then
@@ -66,16 +93,9 @@ func (t *TCPObfuscated) Connect() error {
 		nonce = make([]byte, 64)
 		for {
 			rand.Read(nonce)
-			if nonce[0] == 0xEF {
-				continue
+			if !isForbiddenNonce(nonce) {
+				break
 			}
-			if bytes.Equal(nonce[:4], []byte{0xee, 0xee, 0xee, 0xee}) {
-				continue
-			}
-			if bytes.Equal(nonce[4:8], []byte{0, 0, 0, 0}) {
-				continue
-			}
-			break
 		}
 	}
 


### PR DESCRIPTION
## Summary

Three transport-level hardening fixes identified during the full MTProto 2.0 spec compliance review.

## Changes

### 1. Obfuscated nonce: complete protocol identifier checks
**Spec**: The first 4 bytes of the 64-byte nonce must not match `0xDDDDDDDD`, `0xEEEEEEEE`, `HEAD`, `POST`, `GET `, `OPTIONS`, `0x02010316`, and the first byte must not be `0xEF`.

**Before**: Only checked `0xEEEEEEEE` and `0xEF` — 5 identifiers were missing.
**After**: All 7 forbidden identifiers + first-byte check.

### 2. Max payload limits for all transports
- `tcp_abridged.go`: Added `maxPayloadLen` check on recv (was missing entirely — could allocate arbitrary memory)
- `tcp_full.go`: Added `maxPayloadLen` check on recv
- `tcp_intermediate.go` and `tcp_padded_intermediate.go` already had limits from PR #1

### 3. Transport error code handling
**Spec**: "The server may send a packet with a signed little-endian number of 4 bytes whose absolute value contains the error code."

**Before**: 4-byte error packets were passed to `crypto.UnpackEnvelope` which would fail with a confusing "data too short" or "auth_key_id mismatch" error.
**After**: The readLoop detects 4-byte packets, extracts the error code, reports it via `onDisconnect`, and closes the connection — matching the spec behavior of "close and reestablish TCP connection".

## Test Plan
- [x] `go test ./internal/transport/...` — all pass
- [x] `go test ./internal/session/...` — all pass
- [x] `go test ./telegram/...` — all pass