### PR TITLE
fix(session): close TCP connection on msg_key integrity failure

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1076,6 +1076,12 @@ func (s *Session) readLoop() {
 		}
 		raw, decrypted, err := unpackIncomingMessageEnvelope(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
 		if err != nil {
+			if _, ok := err.(*tgerr.SecurityCheckMismatch); ok {
+				if s.onDisconnect != nil {
+					s.onDisconnect(err)
+				}
+				return
+			}
 			continue
 		}
 


### PR DESCRIPTION
## Summary

Closes the TCP connection when a `msg_key` integrity check fails, as recommended by the MTProto security guidelines.

## Problem

The MTProto spec states: *"We also recommend closing and reestablishing the TCP connection to the server"* when a `msg_key` or `auth_key_id` validation failure is detected.

Previously, the readLoop silently skipped invalid messages with `continue`, keeping the potentially compromised connection alive indefinitely. An attacker who could inject or modify ciphertext could do so without consequence — the client would just skip the bad packets and keep processing.

## Fix

When `crypto.UnpackEnvelope` returns a `*tgerr.SecurityCheckMismatch` error, the readLoop now:
1. Calls `onDisconnect(err)` to signal the connection loss
2. Returns from the readLoop goroutine, closing the connection

The next operation that needs the session will trigger a fresh reconnection.

## Test Plan
- [x] `go test ./internal/session/...` — all pass
- [x] `go test ./telegram/...` — all pass