### PR TITLE
fix(auth): use RSA_PAD (SHA256) for PQ inner data encryption

### DIFF
--- a/internal/session/auth.go
+++ b/internal/session/auth.go
@@ -185,7 +185,7 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 		return nil, fmt.Errorf("step 6: PQInnerData too large (%d bytes)", len(pqInnerBytes))
 	}
 
-	encData, err := crypto.RSAEncryptLegacy(pqInnerBytes, fp)
+	encData, err := crypto.RSAEncrypt(pqInnerBytes, fp)
 	if err != nil {
 		return nil, fmt.Errorf("step 6: RSA encrypt: %w", err)
 	}


### PR DESCRIPTION
## Summary

Switches the auth key exchange from legacy SHA1-based RSA padding to the MTProto 2.0 spec-compliant RSA_PAD scheme with SHA256.

## Problem

MTProto 2.0 specifies that `pq_inner_data` must be encrypted using the RSA_PAD scheme (SHA256-based OAEP+ padding). The codebase already had a correct `rsapad` implementation (used by `RSAEncrypt`), but the auth key generation flow was still calling `RSAEncryptLegacy` which uses the older SHA1-based PKCS#1 padding.

## Fix

One-line change: `crypto.RSAEncryptLegacy` → `crypto.RSAEncrypt` in `internal/session/auth.go:188`.

The `RSAEncrypt` function calls `rsapad()` which implements the spec's:
1. Pad data with random bytes to 192 bytes
2. Generate random temp AES key
3. Compute SHA256(temp_key || data_with_padding)
4. AES-IGE encrypt (data_with_padding_reversed || sha256_hash) with temp_key
5. XOR temp_key with SHA256(aes_encrypted)
6. Verify result < n, retry if not

## Test Plan
- [x] `go test ./internal/crypto/...` — all pass
- [x] `go test ./internal/session/...` — all pass
- [x] `go test ./telegram/...` — all pass