### PR TITLE
feat(session): handle quick ACK and transport error codes in readLoop

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1074,6 +1074,17 @@ func (s *Session) readLoop() {
 			}
 			continue
 		}
+		if len(data) == 4 {
+			code := int32(uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24)
+			if code < 0 {
+				continue
+			}
+			if s.onDisconnect != nil {
+				s.onDisconnect(fmt.Errorf("transport error: code %d", -code))
+			}
+			return
+		}
+
 		raw, decrypted, err := unpackIncomingMessageEnvelope(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
 		if err != nil {
 			continue

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -3,6 +3,7 @@ package session
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"testing"
 	"time"
 
@@ -928,4 +929,78 @@ func TestSessionConnectNoAuthKey(t *testing.T) {
 func unpackIncoming(data []byte, s *Session) *tg.MTProtoMessage {
 	msg, _, _ := crypto.Unpack(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
 	return msg
+}
+
+func TestQuickAck(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+	mt := newMockTransport()
+	s.SetTransport(mt)
+
+	disconnectCh := make(chan error, 1)
+	s.onDisconnect = func(err error) {
+		disconnectCh <- err
+	}
+
+	startTestWorkers(s)
+
+	quickAck := make([]byte, 4)
+	binary.LittleEndian.PutUint32(quickAck, uint32(0x80000001))
+	mt.recvCh <- quickAck
+
+	msgID := s.msgFactory.AllocateMsgID()
+	respMsgID := s.msgFactory.AllocateMsgID()
+	respSeqNo := s.msgFactory.AllocateSeqNo(false)
+	pong := &tg.Pong{MsgID: msgID, PingID: 42}
+	mt.recvCh <- makeEncryptedResponse(s, respMsgID, uint32(respSeqNo), pong)
+
+	sendDone := make(chan error, 1)
+	go func() {
+		_, err := s.Send(context.Background(), msgID, uint32(s.msgFactory.AllocateSeqNo(true)), &tg.PingRequest{PingID: 42}, 5*time.Second)
+		sendDone <- err
+	}()
+
+	select {
+	case err := <-sendDone:
+		if err != nil {
+			t.Fatalf("Send() error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Send() timed out")
+	}
+
+	select {
+	case <-disconnectCh:
+		t.Fatal("quick ack should not cause disconnect")
+	default:
+	}
+
+	close(s.cancel)
+}
+
+func TestTransportErrorCodeCausesDisconnect(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+	mt := newMockTransport()
+	s.SetTransport(mt)
+
+	disconnectCh := make(chan error, 1)
+	s.onDisconnect = func(err error) {
+		disconnectCh <- err
+	}
+
+	startTestWorkers(s)
+
+	errCode := make([]byte, 4)
+	binary.LittleEndian.PutUint32(errCode, uint32(404))
+	mt.recvCh <- errCode
+
+	select {
+	case err := <-disconnectCh:
+		if err == nil {
+			t.Fatal("expected non-nil disconnect error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected disconnect from transport error code")
+	}
+
+	close(s.cancel)
 }


### PR DESCRIPTION
## Summary

Handles the two types of 4-byte packets that MTProto servers may send on encrypted connections, which were previously silently dropped by `crypto.UnpackEnvelope`'s 24-byte minimum check.

## Changes

### Quick ACK (4-byte int32 with MSB set)
The server may send an early acknowledgment as a 4-byte little-endian int32 where the most significant bit is set (value is negative when read as int32). The client should silently consume these — they indicate the server received the message but hasn't processed it yet.

### Transport error codes (4-byte int32 without MSB set)
The server may send a bare error code as a 4-byte little-endian int32 (e.g., -404 for auth key not found, -429 for transport flood). The client must close the connection. Now triggers `onDisconnect` with a descriptive error and exits the readLoop.

### Tests
- `TestQuickAck`: Verifies quick ack is silently consumed without disconnect, and subsequent encrypted messages are still processed.
- `TestTransportErrorCodeCausesDisconnect`: Verifies transport error code triggers disconnect callback.

## Test Plan
- [x] `go test ./...` — all pass
- [x] New tests for both quick ack and transport error handling