### PR TITLE
fix(auth): validate server_nonce, g_a range, dh_prime in auth key creation

### DIFF
--- a/internal/session/auth.go
+++ b/internal/session/auth.go
@@ -210,6 +210,12 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 	case *tg.ServerDHParamsFail:
 		return nil, ErrDHParamsFail
 	case *tg.ServerDHParamsOk:
+		if v.ServerNonce != resPQ.ServerNonce {
+			return nil, ErrServerNonceMismatch
+		}
+		if v.Nonce != nonce {
+			return nil, ErrNonceMismatch
+		}
 		key, iv := computeKeyAndIV(newNonce[:], resPQ.ServerNonce[:])
 		decrypted := crypto.IGEDecrypt([]byte(v.EncryptedAnswer), key, iv)
 		defer crypto.ReleaseAESBuf(decrypted)
@@ -231,13 +237,39 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 		if dhInner.Nonce != nonce {
 			return nil, ErrDHNonceMismatch
 		}
+		if dhInner.ServerNonce != resPQ.ServerNonce {
+			return nil, ErrServerNonceMismatch
+		}
 
-		b := a.generateRandomBN(2048)
 		dhPrime := new(big.Int).SetBytes([]byte(dhInner.DHPrime))
-		g := big.NewInt(int64(dhInner.G))
-		gB := new(big.Int).Exp(g, b, dhPrime)
+		if dhPrime.BitLen() != 2048 || !dhPrime.ProbablyPrime(20) {
+			return nil, ErrDHPrimeInvalid
+		}
+
+		gVal := int64(dhInner.G)
+		if gVal < 2 || gVal > 7 {
+			return nil, ErrGeneratorInvalid
+		}
 
 		gA := new(big.Int).SetBytes([]byte(dhInner.GA))
+		two := big.NewInt(2)
+		lowerBound := new(big.Int).Lsh(two, 2048-64)
+		upperBound := new(big.Int).Sub(dhPrime, lowerBound)
+		if gA.Cmp(two) < 0 || gA.Cmp(new(big.Int).Sub(dhPrime, two)) > 0 {
+			return nil, ErrGAOutOfRange
+		}
+		if gA.Cmp(lowerBound) < 0 || gA.Cmp(upperBound) > 0 {
+			return nil, ErrGAOutOfRange
+		}
+
+		g := big.NewInt(gVal)
+		b := a.generateRandomBN(2048)
+		gB := new(big.Int).Exp(g, b, dhPrime)
+
+		if gB.Cmp(two) < 0 || gB.Cmp(new(big.Int).Sub(dhPrime, two)) > 0 {
+			return nil, ErrGBOutOfRange
+		}
+
 		authKey := computeAuthKey(gA, b, dhPrime)
 
 		clientDHInner := &tg.ClientDHInnerData{
@@ -278,6 +310,12 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 
 		switch v := obj.(type) {
 		case *tg.DHGenOk:
+			if v.ServerNonce != resPQ.ServerNonce {
+				return nil, ErrServerNonceMismatch
+			}
+			if v.Nonce != nonce {
+				return nil, ErrNonceMismatch
+			}
 			expectedHash := computeNewNonceHash1(newNonce[:], authKey)
 			if !bytes.Equal(v.NewNonceHash1[:], expectedHash) {
 				return nil, ErrNewNonceHashMismatch
@@ -300,9 +338,15 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 			}, nil
 
 		case *tg.DHGenRetry:
+			if v.ServerNonce != resPQ.ServerNonce {
+				return nil, ErrServerNonceMismatch
+			}
 			return nil, ErrDHGenRetry
 
 		case *tg.DHGenFail:
+			if v.ServerNonce != resPQ.ServerNonce {
+				return nil, ErrServerNonceMismatch
+			}
 			return nil, ErrDHGenFail
 
 		default:

--- a/internal/session/errors.go
+++ b/internal/session/errors.go
@@ -45,4 +45,18 @@ var (
 	// ErrDHGenFail is returned during key exchange step 10 when the server
 	// responds with dh_gen_fail, indicating the DH key generation failed.
 	ErrDHGenFail = errors.New("step 10: dh_gen_fail")
+
+	// ErrServerNonceMismatch is returned when server_nonce in a server
+	// response does not match the value from step 2.
+	ErrServerNonceMismatch = errors.New("session: server_nonce mismatch")
+	// ErrGAOutOfRange is returned when the server's g_a value falls outside
+	// the acceptable range [2^(2048-64), dh_prime - 2^(2048-64)].
+	ErrGAOutOfRange = errors.New("session: g_a out of acceptable range")
+	// ErrGBOutOfRange is returned when the client's own g_b value falls
+	// outside the range [1, dh_prime - 1].
+	ErrGBOutOfRange = errors.New("session: g_b out of acceptable range")
+	// ErrDHPrimeInvalid is returned when dh_prime is not a 2048-bit prime.
+	ErrDHPrimeInvalid = errors.New("session: dh_prime not 2048-bit prime")
+	// ErrGeneratorInvalid is returned when the DH generator g is not in [2,7].
+	ErrGeneratorInvalid = errors.New("session: generator g not in [2,7]")
 )

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -930,6 +930,14 @@ func (s *Session) handleRawPacket(msgID int64, body []byte) bool {
 	case tg.FutureSaltsTypeID:
 		return s.handleRawFutureSalts(body)
 	case tg.MsgsAckTypeID:
+	case tg.MsgDetailedInfoTypeID:
+		if len(body) >= 20 {
+			s.addAck(int64(binary.LittleEndian.Uint64(body[12:20])))
+		}
+	case tg.MsgNewDetailedInfoTypeID:
+		if len(body) >= 12 {
+			s.addAck(int64(binary.LittleEndian.Uint64(body[4:12])))
+		}
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

Comprehensive auth key generation validation from full MTProto 2.0 spec review of all 11 Telegram documentation pages.

## Changes

### server_nonce validation (Critical)
The spec requires checking `server_nonce` in every server response during key generation. Previously only `nonce` was checked in `ServerDHInnerData`. Now `server_nonce` is validated in:
- `ServerDHParamsOk` (step 6 response)
- `ServerDHInnerData` (decrypted DH params)
- `DHGenOk` (step 9 success)
- `DHGenRetry` (step 9 retry)
- `DHGenFail` (step 9 failure)

Also added `nonce` validation to `ServerDHParamsOk` and `DHGenOk`.

### DH parameter validation (Critical)
Per the security guidelines, all DH parameters must be validated:
- **dh_prime**: Must be exactly 2048 bits and pass `ProbablyPrime(20)` (Miller-Rabin with 20 iterations)
- **g (generator)**: Must be in range [2, 7]
- **g_a**: Must satisfy `2 <= g_a <= dh_prime - 2` (basic check) AND the recommended range `2^(2048-64) <= g_a <= dh_prime - 2^(2048-64)` (strong check)
- **g_b (client's own)**: Must satisfy `2 <= g_b <= dh_prime - 2`

### Service message handling (Medium)
- **MsgDetailedInfo**: Server notifies about a known message — now acknowledged by `answer_msg_id`
- **MsgNewDetailedInfo**: Server notifies about an unacknowledged message — now acknowledged by `answer_msg_id`

### New sentinel errors
- `ErrServerNonceMismatch`
- `ErrGAOutOfRange`
- `ErrGBOutOfRange`
- `ErrDHPrimeInvalid`
- `ErrGeneratorInvalid`

## Spec References
- https://core.telegram.org/mtproto/auth_key (steps 2-9)
- https://core.telegram.org/mtproto/security_guidelines (DH parameter validation)
- https://core.telegram.org/mtproto/service_messages_about_messages (MsgDetailedInfo)

## Test Plan
- [x] `go test ./...` — all pass