### PR TITLE
feat: configurable dispatch worker pool

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -48,7 +48,8 @@ const (
 	saltFetchInterval    = time.Hour
 	ackFlushInterval     = 30 * time.Second
 	housekeeperTick      = time.Second
-	dispatchQueueSize    = 256
+
+	defaultDispatchQueueSize = 256
 )
 
 var sendJobPool = sync.Pool{
@@ -217,6 +218,10 @@ type Session struct {
 	sendCh chan *sendJob
 	// dispatchCh is a bounded queue for raw messages that need TL decoding.
 	dispatchCh chan *tg.MTProtoMessageRaw
+	// dispatchWorkers is the number of workers that decode dispatchCh items.
+	dispatchWorkers int
+	// dispatchQueueSize is the capacity used when creating dispatchCh.
+	dispatchQueueSize int
 	// receiveErr receives the terminal receive loop error, if any.
 	receiveErr chan error
 	// pingInterval controls how often keep-alive pings are sent.
@@ -290,12 +295,38 @@ func NewSession(dc DataCenter, st storage.Storage, deviceModel, appVersion, syst
 		pingInterval: 60 * time.Second,
 		updateSem:    make(chan struct{}, 64),
 	}
+	s.SetDispatchConfig(0, 0)
 
 	if len(authKey) > 0 {
 		s.authKeyID = computeAuthKeyID(authKey)
 	}
 
 	return s, nil
+}
+
+// SetDispatchConfig configures the bounded TL decode worker pool used by the
+// receive path. Non-positive values keep the defaults: runtime.GOMAXPROCS(0)
+// workers and a queue capacity of 256.
+func (s *Session) SetDispatchConfig(workers, queueSize int) {
+	s.dispatchWorkers = resolveDispatchWorkers(workers)
+	s.dispatchQueueSize = resolveDispatchQueueSize(queueSize)
+}
+
+func resolveDispatchWorkers(workers int) int {
+	if workers > 0 {
+		return workers
+	}
+	if workers = runtime.GOMAXPROCS(0); workers > 0 {
+		return workers
+	}
+	return 1
+}
+
+func resolveDispatchQueueSize(queueSize int) int {
+	if queueSize > 0 {
+		return queueSize
+	}
+	return defaultDispatchQueueSize
 }
 
 func (s *Session) registerResult(msgID int64) chan tg.TLObject {
@@ -773,12 +804,12 @@ func (s *Session) StartContext(ctx context.Context) error {
 func (s *Session) start(loopCtx, pingCtx context.Context) error {
 	s.cancel = make(chan struct{})
 	s.sendCh = make(chan *sendJob, 64)
-	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, dispatchQueueSize)
+	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, s.dispatchQueueSize)
 	s.receiveErr = make(chan error, 1)
 	s.connected.Store(true)
 
 	go s.writer()
-	s.startDispatchWorkers(loopCtx, runtime.GOMAXPROCS(0))
+	s.startDispatchWorkers(loopCtx, s.dispatchWorkers)
 	go func() {
 		s.receiveErr <- s.receiveLoop(loopCtx)
 	}()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"runtime"
 	"testing"
 	"time"
 
@@ -271,11 +272,43 @@ func newSessionWithAuthKey(t *testing.T) *Session {
 func startTestWorkers(s *Session) {
 	s.cancel = make(chan struct{})
 	s.sendCh = make(chan *sendJob, 64)
-	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, dispatchQueueSize)
+	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, s.dispatchQueueSize)
 	s.connected.Store(true)
 	go s.writer()
 	s.startDispatchWorkers(context.Background(), 1)
 	go func() { _ = s.receiveLoop(context.Background()) }()
+}
+
+func TestSessionDispatchConfigDefaults(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+
+	if s.dispatchWorkers != runtime.GOMAXPROCS(0) {
+		t.Fatalf("dispatchWorkers = %d, want %d", s.dispatchWorkers, runtime.GOMAXPROCS(0))
+	}
+	if s.dispatchQueueSize != defaultDispatchQueueSize {
+		t.Fatalf("dispatchQueueSize = %d, want %d", s.dispatchQueueSize, defaultDispatchQueueSize)
+	}
+
+	s.SetDispatchConfig(-1, 0)
+	if s.dispatchWorkers != runtime.GOMAXPROCS(0) {
+		t.Fatalf("dispatchWorkers after negative = %d, want %d", s.dispatchWorkers, runtime.GOMAXPROCS(0))
+	}
+	if s.dispatchQueueSize != defaultDispatchQueueSize {
+		t.Fatalf("dispatchQueueSize after zero = %d, want %d", s.dispatchQueueSize, defaultDispatchQueueSize)
+	}
+}
+
+func TestSessionDispatchConfigCustom(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+
+	s.SetDispatchConfig(7, 33)
+
+	if s.dispatchWorkers != 7 {
+		t.Fatalf("dispatchWorkers = %d, want 7", s.dispatchWorkers)
+	}
+	if s.dispatchQueueSize != 33 {
+		t.Fatalf("dispatchQueueSize = %d, want 33", s.dispatchQueueSize)
+	}
 }
 
 func TestSessionSendAndWait(t *testing.T) {

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -213,6 +213,12 @@ func NewClient(apiID int32, apiHash string, cfg *Config) (*Client, error) {
 		if cfg.MaxConcurrentTrans != 0 {
 			c.MaxConcurrentTrans = cfg.MaxConcurrentTrans
 		}
+		if cfg.DispatchWorkers != 0 {
+			c.DispatchWorkers = cfg.DispatchWorkers
+		}
+		if cfg.DispatchQueueSize != 0 {
+			c.DispatchQueueSize = cfg.DispatchQueueSize
+		}
 		if cfg.MaxMessageCacheSize != 0 {
 			c.MaxMessageCacheSize = cfg.MaxMessageCacheSize
 		}
@@ -678,6 +684,13 @@ func (c *Client) Config() Config {
 	return c.cfg
 }
 
+func configureSessionDispatch(sess *session.Session, cfg Config) {
+	if sess == nil {
+		return
+	}
+	sess.SetDispatchConfig(cfg.DispatchWorkers, cfg.DispatchQueueSize)
+}
+
 // SetDispatcher replaces the update dispatcher used to route incoming updates to handlers.
 func (c *Client) SetDispatcher(d Dispatcher) {
 	c.mu.Lock()
@@ -929,6 +942,7 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 			return fmt.Errorf("save dc_id: %w", err)
 		}
 	}
+	configureSessionDispatch(sess, c.cfg)
 	c.session = sess
 
 	dc := sess.DC()
@@ -1887,6 +1901,10 @@ func (c *Client) GetSession(ctx context.Context, dcID int, isMedia bool, isCDN b
 	if err != nil {
 		return nil, fmt.Errorf("create session for dc %d: %w", dcID, err)
 	}
+	c.mu.RLock()
+	cfg := c.cfg
+	c.mu.RUnlock()
+	configureSessionDispatch(sess, cfg)
 
 	c.sessionsMu.Lock()
 	if existing, ok := c.sessions[key]; ok {

--- a/telegram/client_test.go
+++ b/telegram/client_test.go
@@ -29,6 +29,12 @@ func TestNewClientDefaults(t *testing.T) {
 	if c.cfg.MaxConcurrentTrans != 1 {
 		t.Errorf("MaxConcurrentTrans = %d, want 1", c.cfg.MaxConcurrentTrans)
 	}
+	if c.cfg.DispatchWorkers != 0 {
+		t.Errorf("DispatchWorkers = %d, want 0", c.cfg.DispatchWorkers)
+	}
+	if c.cfg.DispatchQueueSize != defaultDispatchQueueSize {
+		t.Errorf("DispatchQueueSize = %d, want %d", c.cfg.DispatchQueueSize, defaultDispatchQueueSize)
+	}
 	if c.cfg.MaxMessageCacheSize != 1000 {
 		t.Errorf("MaxMessageCacheSize = %d, want 1000", c.cfg.MaxMessageCacheSize)
 	}
@@ -76,6 +82,8 @@ func TestNewClientWithOptions(t *testing.T) {
 		NoUpdates:           true,
 		SleepThreshold:      5 * time.Second,
 		MaxConcurrentTrans:  4,
+		DispatchWorkers:     8,
+		DispatchQueueSize:   512,
 		MaxMessageCacheSize: 500,
 		ParseMode:           HTML,
 		HidePassword:        true,
@@ -128,6 +136,12 @@ func TestNewClientWithOptions(t *testing.T) {
 	}
 	if cfg.MaxConcurrentTrans != 4 {
 		t.Errorf("MaxConcurrentTrans = %d", cfg.MaxConcurrentTrans)
+	}
+	if cfg.DispatchWorkers != 8 {
+		t.Errorf("DispatchWorkers = %d", cfg.DispatchWorkers)
+	}
+	if cfg.DispatchQueueSize != 512 {
+		t.Errorf("DispatchQueueSize = %d", cfg.DispatchQueueSize)
 	}
 	if cfg.MaxMessageCacheSize != 500 {
 		t.Errorf("MaxMessageCacheSize = %d", cfg.MaxMessageCacheSize)

--- a/telegram/config.go
+++ b/telegram/config.go
@@ -3,9 +3,9 @@ package telegram
 import (
 	"time"
 
+	"github.com/mtgo-labs/mtgo/internal/storage"
 	"github.com/mtgo-labs/mtgo/telegram/params"
 	"github.com/mtgo-labs/mtgo/telegram/types"
-	"github.com/mtgo-labs/mtgo/internal/storage"
 )
 
 // Proxy holds connection details for routing Telegram traffic through an
@@ -85,6 +85,8 @@ const (
 	TransportModePaddedIntermediate = "PaddedIntermediate"
 	// TransportModeFull selects full TCP framing with sequence numbers and CRC32.
 	TransportModeFull = "Full"
+
+	defaultDispatchQueueSize = 256
 )
 
 // Config contains every tunable parameter for a Telegram MTProto client.
@@ -199,6 +201,16 @@ type Config struct {
 	// MaxConcurrentTrans limits how many file transfers may run in parallel.
 	// Keep low on bandwidth-constrained networks to avoid throttling.
 	MaxConcurrentTrans int
+	// DispatchWorkers sets the number of session workers used to TL-decode
+	// incoming messages before result/update dispatch. Values <= 0 use
+	// runtime.GOMAXPROCS(0). Increase for I/O-heavy update handling; keep near
+	// CPU count for CPU-heavy decoding.
+	DispatchWorkers int
+	// DispatchQueueSize sets the bounded queue capacity for incoming messages
+	// waiting for TL decode. Values <= 0 use the default 256. Larger values
+	// absorb bursts at the cost of memory; smaller values apply backpressure
+	// sooner under high traffic.
+	DispatchQueueSize int
 	// MaxMessageCacheSize caps the number of messages retained in the
 	// internal cache. Older entries are evicted when the limit is exceeded.
 	MaxMessageCacheSize int
@@ -277,7 +289,8 @@ type Config struct {
 	TZOffset int
 	// TransportMode selects the MTProto TCP framing mode for direct TCP
 	// connections. Valid values are Abridged, Intermediate,
-	// PaddedIntermediate, and Full.
+	// PaddedIntermediate, and Full. When empty, NewClient uses the default
+	// Abridged transport mode.
 	TransportMode string
 	// SavePeers persists encountered peer identifiers to the session file so
 	// that they survive restarts without re-fetching.
@@ -376,10 +389,11 @@ type Config struct {
 //	cfg.InMemory = true
 //	client, err := telegram.NewClient(apiID, apiHash, &cfg)
 var DefaultConfig = Config{
-	SleepThreshold:     10 * time.Second,
+	SleepThreshold:      10 * time.Second,
 	Timeout:             60 * time.Second,
 	ReqTimeout:          60 * time.Second,
 	MaxConcurrentTrans:  1,
+	DispatchQueueSize:   defaultDispatchQueueSize,
 	MaxMessageCacheSize: 1000,
 	MaxTopicCacheSize:   1000,
 	PeerCacheSize:       5000,

--- a/telegram/dc_sessions.go
+++ b/telegram/dc_sessions.go
@@ -18,8 +18,8 @@ type dcSessionEntry struct {
 }
 
 type dcSessions struct {
-	mu       sync.Mutex
-	entries  map[int]*dcSessionEntry
+	mu        sync.Mutex
+	entries   map[int]*dcSessionEntry
 	initLocks map[int]*sync.Mutex
 }
 
@@ -145,6 +145,7 @@ func (c *Client) createDCSession(ctx context.Context, dcID int) (*dcSessionEntry
 		sessionTp.Close()
 		return nil, fmt.Errorf("download: create session DC %d: %w", dcID, err)
 	}
+	configureSessionDispatch(sess, cfg)
 
 	auth := &session.Auth{
 		DC:       dcID,

--- a/telegram/reconnect.go
+++ b/telegram/reconnect.go
@@ -120,6 +120,7 @@ func (c *Client) reconnectOnce() error {
 	if err != nil {
 		return fmt.Errorf("create session: %w", err)
 	}
+	configureSessionDispatch(sess, c.cfg)
 
 	addr := fmt.Sprintf("%s:%d", dc.Address(), dc.Port())
 	d := c.dialer


### PR DESCRIPTION
## Summary

Makes the session dispatch worker pool configurable via `telegram.Config` fields.

## Changes

- Add `DispatchWorkers` and `DispatchQueueSize` fields to `telegram.Config` with godoc
- Add `Session.SetDispatchConfig(workers, queueSize)` to configure the bounded TL decode pool
- Apply dispatch config to all session creation points (main, DC file transfers, reconnections)
- Rename `dispatchQueueSize` const to `defaultDispatchQueueSize`
- Add unit tests for default and custom dispatch config

## Defaults

- `DispatchWorkers`: `runtime.GOMAXPROCS(0)` (unchanged)
- `DispatchQueueSize`: 256 (unchanged)

## Test Plan

- [x] `go test ./internal/session/...` — all pass
- [x] `go test ./telegram/...` — all pass
- [x] `go test -short ./...` — all pass