### PR TITLE
fix: add gB range validation in DH key exchange

### DIFF
--- a/internal/session/auth.go
+++ b/internal/session/auth.go
@@ -270,6 +270,11 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 		b := a.generateRandomBN(2048)
 		gB := new(big.Int).Exp(g, b, dhPrime)
 
+		two := big.NewInt(2)
+		if gB.Cmp(two) < 0 || gB.Cmp(new(big.Int).Sub(dhPrime, two)) > 0 {
+			return nil, ErrGBOutOfRange
+		}
+
 		authKey := computeAuthKey(gA, b, dhPrime)
 
 		authKeyAuxHash := func() int64 {

--- a/internal/session/errors.go
+++ b/internal/session/errors.go
@@ -55,4 +55,7 @@ var (
 	// ErrGAOutOfRange is returned when the server's g_a falls outside the
 	// required range [2, dh_prime-2].
 	ErrGAOutOfRange = errors.New("session: g_a out of range")
+	// ErrGBOutOfRange is returned when the client's computed g_b falls
+	// outside the required range [2, dh_prime-2].
+	ErrGBOutOfRange = errors.New("session: g_b out of range")
 )


### PR DESCRIPTION
## Summary

Adds the missing gB range check in the DH key exchange that was lost during PR #14 conflict resolution.

## Changes

- Add `ErrGBOutOfRange` sentinel error with godoc to `errors.go`
- Validate `gB` satisfies `2 <= gB <= dh_prime - 2` per MTProto spec (`auth.go:273-275`)

## Test Plan

- [x] `go test ./internal/session/...` — pass
- [x] `go test -short ./...` — pass
- [x] Test DC — connected, GetMe, GetConfig all pass