### PR TITLE
fix: prevent session teardown under burst load

### DIFF
--- a/examples/echo_bot/main.go
+++ b/examples/echo_bot/main.go
@@ -16,9 +16,10 @@ func main() {
 	botToken := mustEnv("BOT_TOKEN")
 
 	client, err := telegram.NewClient(mustAtoi(apiID), apiHash, &telegram.Config{
-		BotToken:    botToken,
-		SessionName: "echo_bot",
-		SavePeers:   true,
+		BotToken:          botToken,
+		SessionName:       "echo_bot",
+		SavePeers:         true,
+		DispatchQueueSize: 512,
 	})
 	if err != nil {
 		log.Fatalf("new client: %v", err)

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -507,9 +507,6 @@ func (s *Session) Send(ctx context.Context, msgID int64, seqNo uint32, body tg.T
 	if err := <-job.done; err != nil {
 		putSendJob(job)
 		s.unregisterResult(msgID)
-		if s.onDisconnect != nil {
-			s.onDisconnect(err)
-		}
 		return nil, fmt.Errorf("session: send: %w", err)
 	}
 	putSendJob(job)
@@ -663,9 +660,6 @@ func (s *Session) SendRaw(ctx context.Context, msgID int64, seqNo uint32, bodyBy
 	if err := <-job.done; err != nil {
 		putSendJob(job)
 		s.unregisterRawResult(msgID)
-		if s.onDisconnect != nil {
-			s.onDisconnect(err)
-		}
 		return nil, fmt.Errorf("session: send raw: %w", err)
 	}
 	putSendJob(job)
@@ -803,7 +797,7 @@ func (s *Session) StartContext(ctx context.Context) error {
 
 func (s *Session) start(loopCtx, pingCtx context.Context) error {
 	s.cancel = make(chan struct{})
-	s.sendCh = make(chan *sendJob, 64)
+	s.sendCh = make(chan *sendJob, 256)
 	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, s.dispatchQueueSize)
 	s.receiveErr = make(chan error, 1)
 	s.connected.Store(true)
@@ -956,8 +950,11 @@ func (s *Session) writer() {
 			} else {
 				putSendJob(job)
 			}
-			if err != nil && s.onDisconnect != nil {
-				s.onDisconnect(err)
+			if err != nil {
+				if s.onDisconnect != nil {
+					s.onDisconnect(err)
+				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes session disconnect (`ErrNotConnected`) under burst load (150+ rapid invocations).

## Root Cause

The `writer()` goroutine called `onDisconnect(err)` on **every** write failure but continued the loop, causing repeated disconnect callbacks for the same transport failure. Under high concurrency:

1. 150+ invocations fill the `sendCh` (cap 64)
2. One write deadline expiry triggers `onDisconnect` → `triggerReconnect` → full session teardown
3. `Invoke`/`SendRaw` also redundantly called `onDisconnect` on `job.done` errors, multiplying the callbacks

## Changes

- **`writer()`**: exit after first write error (calls `onDisconnect` once, then returns). Prevents repeated callbacks and lets the caller (`triggerReconnect`) handle reconnection
- **Remove redundant `onDisconnect` calls** from `Invoke` and `SendRaw` — the writer is the single authority for transport failure notification
- **Increase `sendCh` capacity** from 64 → 256 to absorb burst traffic without `ErrSendTimeout`

## Test Plan

- [x] `go test -short ./...` — all pass
- [x] `go test ./internal/session/...` — all pass
- [x] Test DC stress test: 150 concurrent invocations (15 goroutines), 150/150 passed at 59/s, no disconnects
- [x] Test DC: GetMe, GetConfig after stress — all pass