### PR TITLE
feat: add optional params to high-level reaction/payment methods

### DIFF
--- a/telegram/bound.go
+++ b/telegram/bound.go
@@ -202,7 +202,7 @@ func (c *Client) BoundReact(chatID int64, msgID int32, opts ...*params.React) er
 	ctx := context.Background()
 	o := params.GetOptDef(&params.React{}, opts...)
 	reactions := []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: o.Emoji}}
-	return c.SendReaction(ctx, chatID, msgID, reactions...)
+	return c.SendReaction(ctx, chatID, msgID, reactions)
 }
 
 // BoundPin pins a message in the specified chat. This is a bound-method

--- a/telegram/context_message.go
+++ b/telegram/context_message.go
@@ -295,7 +295,7 @@ func (c *Context) React(reaction ...tg.ReactionClass) error {
 	if err != nil {
 		return err
 	}
-	return c.Client.SendReaction(c.Ctx, chatID, c.Message.ID, reaction...)
+	return c.Client.SendReaction(c.Ctx, chatID, c.Message.ID, reaction)
 }
 
 // Read marks the message that triggered the current context as read. If no specific message

--- a/telegram/messages_reactions.go
+++ b/telegram/messages_reactions.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/mtgo-labs/mtgo/telegram/params"
 	"github.com/mtgo-labs/mtgo/tg"
 )
 
@@ -28,25 +29,23 @@ import (
 //	if err != nil {
 //	    log.Fatal(err)
 //	}
-func (c *Client) SendReaction(ctx context.Context, chatID int64, messageID int32, reaction ...tg.ReactionClass) error {
+func (c *Client) SendReaction(ctx context.Context, chatID int64, messageID int32, reaction []tg.ReactionClass, opts ...*params.SendReactionOption) error {
 	c.Log.Debugf("SendReaction chat_id=%d msg_id=%d", chatID, messageID)
 	peer, err := resolvePeer(c, chatID)
 	if err != nil {
 		return fmt.Errorf("resolve peer: %w", err)
 	}
 
-	var flags tg.Fields
-	flags.Set(0)
+	opt := params.GetOptDef(&params.SendReactionOption{}, opts...)
 
 	rpc := c.Raw()
 	_, err = rpc.MessagesSendReaction(ctx, &tg.MessagesSendReactionRequest{
-		Flags:    flags,
-		Peer:     peer,
-		MsgID:    messageID,
-		Reaction: reaction,
+		Big:         opt.Big,
+		AddToRecent: opt.AddToRecent,
+		Peer:        peer,
+		MsgID:       messageID,
+		Reaction:    reaction,
 	})
-	if err != nil {
-	}
 	return err
 }
 
@@ -65,12 +64,14 @@ func (c *Client) SendReaction(ctx context.Context, chatID int64, messageID int32
 //   - the user has insufficient Stars balance
 //   - paid reactions are not available for this message
 //   - the RPC call fails
-func (c *Client) SendPaidReaction(ctx context.Context, chatID int64, messageID int32, amount int64) error {
+func (c *Client) SendPaidReaction(ctx context.Context, chatID int64, messageID int32, amount int64, opts ...*params.SendPaidReactionOption) error {
 	c.Log.Debugf("SendPaidReaction chat_id=%d msg_id=%d amount=%d", chatID, messageID, amount)
 	peer, err := resolvePeer(c, chatID)
 	if err != nil {
 		return fmt.Errorf("resolve peer: %w", err)
 	}
+
+	opt := params.GetOptDef(&params.SendPaidReactionOption{}, opts...)
 
 	rpc := c.Raw()
 	_, err = rpc.MessagesSendPaidReaction(ctx, &tg.MessagesSendPaidReactionRequest{
@@ -78,9 +79,8 @@ func (c *Client) SendPaidReaction(ctx context.Context, chatID int64, messageID i
 		MsgID:    messageID,
 		Count:    int32(amount),
 		RandomID: c.RandomID(),
+		Private:  opt.Private,
 	})
-	if err != nil {
-	}
 	return err
 }
 

--- a/telegram/messages_test.go
+++ b/telegram/messages_test.go
@@ -447,7 +447,7 @@ func TestSendReaction(t *testing.T) {
 	c, inv := newClientWithMock(t)
 	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
 
-	err := c.SendReaction(context.Background(), 10, 55, &tg.ReactionEmoji{Emoticon: "\U0001F525"})
+	err := c.SendReaction(context.Background(), 10, 55, []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: "\U0001F525"}})
 	if err != nil {
 		t.Fatalf("SendReaction() error: %v", err)
 	}
@@ -468,8 +468,10 @@ func TestSendReactionMultiple(t *testing.T) {
 	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
 
 	err := c.SendReaction(context.Background(), 10, 55,
-		&tg.ReactionEmoji{Emoticon: "\U0001F525"},
-		&tg.ReactionCustomEmoji{DocumentID: 12345},
+		[]tg.ReactionClass{
+			&tg.ReactionEmoji{Emoticon: "\U0001F525"},
+			&tg.ReactionCustomEmoji{DocumentID: 12345},
+		},
 	)
 	if err != nil {
 		t.Fatalf("SendReaction() error: %v", err)
@@ -480,6 +482,29 @@ func TestSendReactionMultiple(t *testing.T) {
 	}
 	if len(req.Reaction) != 2 {
 		t.Errorf("expected 2 reactions, got %d", len(req.Reaction))
+	}
+}
+
+func TestSendReactionWithOptions(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	err := c.SendReaction(context.Background(), 10, 55,
+		[]tg.ReactionClass{&tg.ReactionEmoji{Emoticon: "\U0001F525"}},
+		&params.SendReactionOption{Big: true, AddToRecent: true},
+	)
+	if err != nil {
+		t.Fatalf("SendReaction() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendReactionRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendReactionRequest, got %T", inv.lastCall())
+	}
+	if !req.Big {
+		t.Error("Big = false, want true")
+	}
+	if !req.AddToRecent {
+		t.Error("AddToRecent = false, want true")
 	}
 }
 
@@ -505,7 +530,7 @@ func TestSendPaidReaction(t *testing.T) {
 
 func TestSendReactionPeerError(t *testing.T) {
 	c, _ := newClientWithMock(t)
-	err := c.SendReaction(context.Background(), 999, 1, &tg.ReactionEmoji{Emoticon: "\U0001F44D"})
+	err := c.SendReaction(context.Background(), 999, 1, []tg.ReactionClass{&tg.ReactionEmoji{Emoticon: "\U0001F44D"}})
 	if err == nil {
 		t.Fatal("expected error for unresolved peer")
 	}

--- a/telegram/params/params.go
+++ b/telegram/params/params.go
@@ -1241,3 +1241,18 @@ type GiftPurchaseOffer struct {
 	Duration             int32
 	PaidMessageStarCount *int64
 }
+
+type SendReactionOption struct {
+	Big         bool
+	AddToRecent bool
+}
+
+type SendPaidReactionOption struct {
+	Private tl.PaidReactionPrivacyClass
+}
+
+type GetStarsTransactionsOption struct {
+	Ascending      bool
+	SubscriptionID string
+	Ton            bool
+}

--- a/telegram/payments_client.go
+++ b/telegram/payments_client.go
@@ -198,7 +198,7 @@ func (c *Client) AnswerShippingQuery(ctx context.Context, queryID int64, ok bool
 // Returns an error if:
 //   - the peer cannot be resolved
 //   - the RPC call fails
-func (c *Client) GetStarsTransactions(ctx context.Context, chatID int64, inbound, outbound bool, offset string, limit int32) (*tg.PaymentsStarsStatus, error) {
+func (c *Client) GetStarsTransactions(ctx context.Context, chatID int64, inbound, outbound bool, offset string, limit int32, opts ...*params.GetStarsTransactionsOption) (*tg.PaymentsStarsStatus, error) {
 	c.Log.Debugf("GetStarsTransactions chat_id=%d inbound=%v outbound=%v limit=%d", chatID, inbound, outbound, limit)
 	peer, err := resolvePeer(c, chatID)
 	if err != nil {
@@ -209,13 +209,18 @@ func (c *Client) GetStarsTransactions(ctx context.Context, chatID int64, inbound
 		limit = 100
 	}
 
+	opt := params.GetOptDef(&params.GetStarsTransactionsOption{}, opts...)
+
 	rpc := c.Raw()
 	return rpc.PaymentsGetStarsTransactions(ctx, &tg.PaymentsGetStarsTransactionsRequest{
-		Inbound:  inbound,
-		Outbound: outbound,
-		Peer:     peer,
-		Offset:   offset,
-		Limit:    limit,
+		Inbound:        inbound,
+		Outbound:       outbound,
+		Ascending:      opt.Ascending,
+		SubscriptionID: opt.SubscriptionID,
+		Ton:            opt.Ton,
+		Peer:           peer,
+		Offset:         offset,
+		Limit:          limit,
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds optional parameter structs to the high-level methods that have flagged fields in the underlying TL requests.

## Changes

| Method | New Options | TL Fields |
|---|---|---|
| `SendReaction` | `params.SendReactionOption{Big, AddToRecent}` | flag 1, flag 2 |
| `SendPaidReaction` | `params.SendPaidReactionOption{Private}` | flag 0 |
| `GetStarsTransactions` | `params.GetStarsTransactionsOption{Ascending, SubscriptionID, Ton}` | flag 2, flag 3, flag 4 |

**Breaking change**: `SendReaction` signature changed from `reaction ...tg.ReactionClass` to `reaction []tg.ReactionClass` + optional `opts ...*params.SendReactionOption`. All internal callers updated.

## Test Plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./...` — all pass
- [x] New test: `TestSendReactionWithOptions` validates Big + AddToRecent