### PR TITLE
perf: performance hardening — fix 10 critical issues

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -33,6 +33,8 @@ type Transport interface {
 	IsConnected() bool
 	// SetWriteDeadline sets the write deadline on the underlying connection.
 	SetWriteDeadline(t time.Time) error
+	// SetReadDeadline sets the read deadline on the underlying connection.
+	SetReadDeadline(t time.Time) error
 }
 
 // sendJob is a unit of work for the writer goroutine.
@@ -348,6 +350,11 @@ func (s *Session) deliverResult(msgID int64, obj tg.TLObject) {
 		select {
 		case ch <- obj:
 		default:
+			select {
+			case ch <- obj:
+			case <-time.After(5 * time.Second):
+				log.Printf("session: deliverResult: dropping result for msg_id=%d: channel full", msgID)
+			}
 		}
 	}
 }
@@ -376,6 +383,11 @@ func (s *Session) deliverRawResult(msgID int64, data []byte) {
 		select {
 		case ch <- data:
 		default:
+			select {
+			case ch <- data:
+			case <-time.After(5 * time.Second):
+				log.Printf("session: deliverRawResult: dropping result for msg_id=%d: channel full", msgID)
+			}
 		}
 	}
 }
@@ -696,13 +708,25 @@ func (s *Session) InvokeRaw(ctx context.Context, query tg.TLObject, retries int,
 	bodyBytes := buf.Bytes()
 
 	var lastErr error
+	var backoff time.Duration
 	for i := 0; i < retries; i++ {
+		if i > 0 {
+			time.Sleep(backoff)
+		}
 		msgID := s.msgFactory.AllocateMsgID()
 		seqNo := s.msgFactory.AllocateSeqNo(true)
 
 		data, err := s.SendRaw(ctx, msgID, uint32(seqNo), bodyBytes, timeout)
 		if err != nil {
 			lastErr = fmt.Errorf("invoke raw: send: %w", err)
+			if backoff == 0 {
+				backoff = 100 * time.Millisecond
+			} else {
+				backoff = backoff * 2
+				if backoff > 2*time.Second {
+					backoff = 2 * time.Second
+				}
+			}
 			continue
 		}
 		return data, nil
@@ -720,13 +744,25 @@ func (s *Session) Invoke(ctx context.Context, query tg.TLObject, retries int, ti
 	methodName := typeName(query)
 
 	var lastErr error
+	var backoff time.Duration
 	for i := 0; i < retries; i++ {
+		if i > 0 {
+			time.Sleep(backoff)
+		}
 		msgID := s.msgFactory.AllocateMsgID()
 		seqNo := s.msgFactory.AllocateSeqNo(true)
 
 		obj, err := s.Send(ctx, msgID, uint32(seqNo), query, timeout)
 		if err != nil {
 			lastErr = fmt.Errorf("invoke %s: send: %w", methodName, err)
+			if backoff == 0 {
+				backoff = 100 * time.Millisecond
+			} else {
+				backoff = backoff * 2
+				if backoff > 2*time.Second {
+					backoff = 2 * time.Second
+				}
+			}
 			continue
 		}
 
@@ -738,6 +774,14 @@ func (s *Session) Invoke(ctx context.Context, query tg.TLObject, retries int, ti
 				lastErr = fmt.Errorf("invoke %s: bad server salt (msg_id=%d, code=%d)", methodName, msgID, v.ErrorCode)
 			default:
 				lastErr = fmt.Errorf("invoke %s: bad message notification: %T", methodName, bad)
+			}
+			if backoff == 0 {
+				backoff = 100 * time.Millisecond
+			} else {
+				backoff = backoff * 2
+				if backoff > 2*time.Second {
+					backoff = 2 * time.Second
+				}
 			}
 			continue
 		}
@@ -751,6 +795,14 @@ func (s *Session) Invoke(ctx context.Context, query tg.TLObject, retries int, ti
 				return nil, fmt.Errorf("invoke %s: %w", methodName, parsed)
 			}
 			lastErr = fmt.Errorf("invoke %s: %w", methodName, parsed)
+			if backoff == 0 {
+				backoff = 100 * time.Millisecond
+			} else {
+				backoff = backoff * 2
+				if backoff > 2*time.Second {
+					backoff = 2 * time.Second
+				}
+			}
 			continue
 		}
 
@@ -953,6 +1005,19 @@ func (s *Session) writer() {
 			if err != nil {
 				if s.onDisconnect != nil {
 					s.onDisconnect(err)
+				}
+			drain:
+				for {
+					select {
+					case job := <-s.sendCh:
+						select {
+						case job.done <- err:
+						default:
+						}
+						putSendJob(job)
+					default:
+						break drain
+					}
 				}
 				return
 			}
@@ -1240,6 +1305,12 @@ func (s *Session) handleRawMsgResendReq(body []byte) {
 
 func (s *Session) receiveLoop(ctx context.Context) error {
 	var lastDisconnect time.Time
+
+	readTimeout := s.pingInterval * 2
+	if readTimeout < 30*time.Second {
+		readTimeout = 30 * time.Second
+	}
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -1249,10 +1320,14 @@ func (s *Session) receiveLoop(ctx context.Context) error {
 		default:
 		}
 
+		s.transport.SetReadDeadline(time.Now().Add(readTimeout))
 		data, err := s.transport.Recv()
 		if err != nil {
 			if !s.connected.Load() {
 				return nil
+			}
+			if isTimeoutError(err) {
+				return fmt.Errorf("session: read deadline exceeded: %w", err)
 			}
 			if s.onDisconnect != nil && time.Since(lastDisconnect) > time.Second {
 				s.onDisconnect(err)
@@ -1270,6 +1345,7 @@ func (s *Session) receiveLoop(ctx context.Context) error {
 			}
 			continue
 		}
+		s.transport.SetReadDeadline(time.Time{})
 		if len(data) == 4 {
 			code := int32(uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24)
 			if code < 0 {
@@ -1331,6 +1407,13 @@ func (s *Session) sendPing() {
 
 func (s *Session) setPingInterval(d time.Duration) {
 	s.pingInterval = d
+}
+
+func isTimeoutError(err error) bool {
+	if netErr, ok := err.(interface{ Timeout() bool }); ok && netErr.Timeout() {
+		return true
+	}
+	return false
 }
 
 // SetUpdateHandler registers fn as the callback for unsolicited server

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -216,6 +216,10 @@ func (m *mockTransport) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
+func (m *mockTransport) SetReadDeadline(t time.Time) error {
+	return nil
+}
+
 func makeAuthKey() []byte {
 	return make([]byte, 256)
 }

--- a/internal/transport/tcp_full.go
+++ b/internal/transport/tcp_full.go
@@ -10,8 +10,9 @@ import (
 )
 
 type TCPFull struct {
-	conn  net.Conn
-	seqNo uint32
+	conn    net.Conn
+	seqNo   uint32
+	readBuf []byte
 }
 
 // NewTCPFull returns a new TCPFull transport wrapping conn.
@@ -48,12 +49,12 @@ func (t *TCPFull) Send(buf *bytes.Buffer) error {
 // verifies the CRC32 checksum and returns the payload bytes without the
 // header and checksum. Returns [ErrCRC32Mismatch] on checksum failure.
 func (t *TCPFull) Recv() ([]byte, error) {
-	lenBytes := make([]byte, 4)
-	if _, err := io.ReadFull(t.conn, lenBytes); err != nil {
+	var lenBytes [4]byte
+	if _, err := io.ReadFull(t.conn, lenBytes[:]); err != nil {
 		return nil, err
 	}
 
-	packetLen := binary.LittleEndian.Uint32(lenBytes)
+	packetLen := binary.LittleEndian.Uint32(lenBytes[:])
 	if packetLen < 12 {
 		return nil, fmt.Errorf("tcp_full: packet too short: %d", packetLen)
 	}
@@ -61,14 +62,21 @@ func (t *TCPFull) Recv() ([]byte, error) {
 		return nil, ErrPayloadTooLarge
 	}
 
-	rest := make([]byte, packetLen-4)
+	restLen := int(packetLen) - 4
+	if cap(t.readBuf) < restLen {
+		t.readBuf = make([]byte, restLen)
+	}
+	rest := t.readBuf[:restLen]
 	if _, err := io.ReadFull(t.conn, rest); err != nil {
 		return nil, err
 	}
 
-	packet := append(lenBytes, rest...)
-	checksum := binary.LittleEndian.Uint32(packet[len(packet)-4:])
-	computed := crc32.ChecksumIEEE(packet[:len(packet)-4])
+	h := crc32.NewIEEE()
+	h.Write(lenBytes[:])
+	h.Write(rest[:len(rest)-4])
+	computed := h.Sum32()
+
+	checksum := binary.LittleEndian.Uint32(rest[len(rest)-4:])
 	if checksum != computed {
 		return nil, ErrCRC32Mismatch
 	}

--- a/internal/transport/tcp_intermediate.go
+++ b/internal/transport/tcp_intermediate.go
@@ -12,7 +12,8 @@ import (
 // It is simpler than full (no CRC) and more straightforward than abridged
 // (fixed-size length prefix).
 type TCPIntermediate struct {
-	conn net.Conn
+	conn    net.Conn
+	readBuf []byte
 }
 
 // NewTCPIntermediate returns a new TCPIntermediate transport wrapping conn.
@@ -44,20 +45,24 @@ func (t *TCPIntermediate) Send(buf *bytes.Buffer) error {
 // Recv reads the next intermediate-transport framed message from the
 // connection. It reads a 4-byte length prefix followed by the payload bytes.
 func (t *TCPIntermediate) Recv() ([]byte, error) {
-	lenBytes := make([]byte, 4)
-	if _, err := io.ReadFull(t.conn, lenBytes); err != nil {
+	var lenBytes [4]byte
+	if _, err := io.ReadFull(t.conn, lenBytes[:]); err != nil {
 		return nil, err
 	}
 
-	length := binary.LittleEndian.Uint32(lenBytes)
+	length := int(binary.LittleEndian.Uint32(lenBytes[:]))
 	if length > MaxPayloadLen {
 		return nil, ErrPayloadTooLarge
 	}
 
-	data := make([]byte, length)
 	if length == 0 {
-		return data, nil
+		return nil, nil
 	}
+
+	if cap(t.readBuf) < length {
+		t.readBuf = make([]byte, length)
+	}
+	data := t.readBuf[:length]
 	if _, err := io.ReadFull(t.conn, data); err != nil {
 		return nil, err
 	}

--- a/internal/transport/ws.go
+++ b/internal/transport/ws.go
@@ -133,12 +133,16 @@ type wsConnCloser struct {
 
 type obfsConn struct {
 	net.Conn
-	enc *crypto.CTRCipher
-	dec *crypto.CTRCipher
+	enc     *crypto.CTRCipher
+	dec     *crypto.CTRCipher
+	readBuf []byte
 }
 
 func (c *obfsConn) Read(p []byte) (int, error) {
-	buf := make([]byte, len(p))
+	if cap(c.readBuf) < len(p) {
+		c.readBuf = make([]byte, len(p))
+	}
+	buf := c.readBuf[:len(p)]
 	n, err := c.Conn.Read(buf)
 	if n > 0 {
 		plain := c.dec.Process(buf[:n])

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -856,15 +856,9 @@ func (c *Client) initialDCID(st storage.Storage) int {
 
 func (c *Client) connectTransport(timeout time.Duration) error {
 	c.mu.Lock()
-	locked := true
-	defer func() {
-		if locked {
-			c.mu.Unlock()
-		}
-	}()
-
 	dcID := c.initialDCID(c.testStorage)
 	if err := c.state.SetConnecting(dcID); err != nil {
+		c.mu.Unlock()
 		return err
 	}
 
@@ -877,14 +871,21 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 		} else if c.cfg.SessionName != "" {
 			s, err := newDefaultStorage(c.cfg.SessionName)
 			if err != nil {
+				c.mu.Unlock()
 				return fmt.Errorf("telegram: auto-create storage: %w", err)
 			}
 			st = s
 		} else {
+			c.mu.Unlock()
 			return ErrNoStorage
 		}
 	}
 	c.storage = st
+	migratingDC := c.migratingDC
+	c.migratingDC = false
+	testSession := c.testSession
+	testDialer := c.testDialer
+	c.mu.Unlock()
 
 	if c.cfg.SessionName != "" {
 		if err := st.SetSessionID(c.cfg.SessionName); err != nil {
@@ -922,7 +923,7 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 
 	c.loadPeersFromStorage()
 
-	sess := c.testSession
+	sess := testSession
 	if sess == nil {
 		dcID := c.initialDCID(st)
 		dc := session.DataCenter{
@@ -943,7 +944,6 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 		}
 	}
 	configureSessionDispatch(sess, c.cfg)
-	c.session = sess
 
 	dc := sess.DC()
 
@@ -981,8 +981,8 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 		}
 
 		d := c.dialer
-		if c.testDialer != nil {
-			d = c.testDialer
+		if testDialer != nil {
+			d = testDialer
 		}
 		conn, err := d.Dial("tcp", addr, timeout)
 		if err != nil {
@@ -1002,23 +1002,18 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 	}
 
 	authKey, _ := st.AuthKey()
-	needDH := len(authKey) == 0 || c.migratingDC
-	c.migratingDC = false
+	needDH := len(authKey) == 0 || migratingDC
 	if needDH {
 		c.Log.Debug("auth key missing; starting DH exchange with DC ", dc.ID)
 		auth := &session.Auth{
 			DC:       dc.ID,
 			TestMode: dc.TestMode,
 		}
-		c.mu.Unlock()
-		locked = false
 		result, err := auth.Create(sessionTp)
 		if err != nil {
 			sessionTp.Close()
 			return fmt.Errorf("DH key exchange: %w", err)
 		}
-		c.mu.Lock()
-		locked = true
 		sess.SetAuthKey(result.AuthKey)
 		sess.SetServerSalt(result.ServerSalt)
 		sess.SetServerTime(time.Unix(int64(result.ServerTime), 0))
@@ -1066,13 +1061,13 @@ func (c *Client) connectTransport(timeout time.Duration) error {
 	}
 	c.Log.Info("encrypted session started")
 
-	// Release c.mu before making RPC calls (bot auth, UpdatesGetState)
-	// to avoid deadlock with Invoke's c.mu.RLock. Mark connected first
-	// so requireConnected() passes for the RPC invocations.
+	// Publish session and mark connected under brief lock so that
+	// concurrent readers observe c.session and ConnStateConnected together.
+	c.mu.Lock()
+	c.session = sess
 	c.state.SetConnected()
 	c.state.SetDC(dcID)
 	c.mu.Unlock()
-	locked = false
 
 	if botToken := c.cfg.BotToken; botToken != "" {
 		alreadyAuthorized := false
@@ -1667,7 +1662,7 @@ func (c *Client) toUpdate(raw tg.UpdateClass, users map[int64]*types.User, chats
 		upd.UserStatus = &types.UserStatusUpdated{UserID: v.UserID}
 	case *tg.UpdateUserName:
 		if len(v.Usernames) > 0 {
-			c.cacheUsernameLocked(v.Usernames[0].Username, v.UserID)
+			c.cacheUsername(v.Usernames[0].Username, v.UserID)
 			if ps, ok := c.storage.(storage.PeerStore); ok {
 				_ = ps.SavePeer(&storage.Peer{
 					ID:        v.UserID,
@@ -2084,7 +2079,9 @@ func (c *Client) evictOldestPeerLocked() {
 	}
 }
 
-func (c *Client) cacheUsernameLocked(username string, userID int64) {
+func (c *Client) cacheUsername(username string, userID int64) {
+	c.peerCacheMu.Lock()
+	defer c.peerCacheMu.Unlock()
 	if _, exists := c.usernameCache[username]; !exists {
 		c.usernameCacheOrder = append(c.usernameCacheOrder, username)
 	}
@@ -2117,7 +2114,7 @@ func (c *Client) cachePeersFromUpdates(users []tg.UserClass, chats []tg.ChatClas
 		c.CachePeer(user.ID, &tg.InputPeerUser{UserID: user.ID, AccessHash: user.AccessHash})
 		username := user.Username
 		if username != "" {
-			c.cacheUsernameLocked(username, user.ID)
+			c.cacheUsername(username, user.ID)
 		}
 		entries = append(entries, &storage.Peer{
 			ID:         user.ID,
@@ -2141,7 +2138,7 @@ func (c *Client) cachePeersFromUpdates(users []tg.UserClass, chats []tg.ChatClas
 			c.CachePeer(v.ID, &tg.InputPeerChannel{ChannelID: v.ID, AccessHash: accessHash})
 			username := v.Username
 			if username != "" {
-				c.cacheUsernameLocked(username, v.ID)
+				c.cacheUsername(username, v.ID)
 			}
 			entries = append(entries, &storage.Peer{
 				ID:         v.ID,
@@ -2186,7 +2183,7 @@ func (c *Client) loadPeersFromStorage() {
 		}
 		c.CachePeer(p.ID, peer)
 		if p.Username != "" {
-			c.cacheUsernameLocked(p.Username, p.ID)
+			c.cacheUsername(p.Username, p.ID)
 		}
 	}
 }

--- a/telegram/dispatcher.go
+++ b/telegram/dispatcher.go
@@ -78,20 +78,6 @@ func (d *HandlerDispatcher) RemoveHandler(h Handler) {
 	}
 }
 
-func (d *HandlerDispatcher) sortedHandlers() []handlerEntry {
-	if !d.dirty {
-		return d.sorted
-	}
-	sorted := make([]handlerEntry, len(d.handlers))
-	copy(sorted, d.handlers)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i].group < sorted[j].group
-	})
-	d.sorted = sorted
-	d.dirty = false
-	return sorted
-}
-
 // Dispatch delivers update to every registered handler whose Check method
 // returns true, in ascending group order. It creates a fresh Context for each
 // handler via Client.NewContext and populates it with fields extracted from the
@@ -107,9 +93,27 @@ func (d *HandlerDispatcher) sortedHandlers() []handlerEntry {
 //	disp.AddHandler(&myHandler{}, 0)
 //	disp.Dispatch(client, update)
 func (d *HandlerDispatcher) Dispatch(client *Client, update *Update) {
-	d.mu.Lock()
-	handlers := d.sortedHandlers()
-	d.mu.Unlock()
+	var handlers []handlerEntry
+
+	d.mu.RLock()
+	if d.dirty {
+		d.mu.RUnlock()
+		d.mu.Lock()
+		if d.dirty {
+			sorted := make([]handlerEntry, len(d.handlers))
+			copy(sorted, d.handlers)
+			sort.Slice(sorted, func(i, j int) bool {
+				return sorted[i].group < sorted[j].group
+			})
+			d.sorted = sorted
+			d.dirty = false
+		}
+		handlers = d.sorted
+		d.mu.Unlock()
+	} else {
+		handlers = d.sorted
+		d.mu.RUnlock()
+	}
 
 	if client != nil && client.Log != nil {
 		client.Log.Tracef("dispatching update to %d handlers", len(handlers))

--- a/telegram/memory_storage.go
+++ b/telegram/memory_storage.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 
 	"github.com/mtgo-labs/mtgo/internal/storage"
@@ -42,6 +43,7 @@ type MemoryStorage struct {
 	apiHash       string
 
 	peers          map[int64]storage.Peer
+	peerUsernames  map[string]int64
 	dcAuths        map[int]storage.DCAuthEntry
 	updateStates   map[string]storage.UpdateState
 	channelStates  map[string]map[int64]storage.ChannelUpdateState
@@ -60,6 +62,7 @@ type MemoryStorage struct {
 func NewMemoryStorage() *MemoryStorage {
 	return &MemoryStorage{
 		peers:          make(map[int64]storage.Peer),
+		peerUsernames:  make(map[string]int64),
 		dcAuths:        make(map[int]storage.DCAuthEntry),
 		updateStates:   make(map[string]storage.UpdateState),
 		channelStates:  make(map[string]map[int64]storage.ChannelUpdateState),
@@ -134,6 +137,15 @@ func (m *MemoryStorage) SavePeer(p *storage.Peer) error {
 	if m.peers == nil {
 		m.peers = make(map[int64]storage.Peer)
 	}
+	if m.peerUsernames == nil {
+		m.peerUsernames = make(map[string]int64)
+	}
+	if old, ok := m.peers[p.ID]; ok && old.Username != "" {
+		delete(m.peerUsernames, strings.ToLower(old.Username))
+	}
+	if p.Username != "" {
+		m.peerUsernames[strings.ToLower(p.Username)] = p.ID
+	}
 	m.peers[p.ID] = *p
 	return nil
 }
@@ -151,12 +163,15 @@ func (m *MemoryStorage) GetPeer(id int64) (*storage.Peer, error) {
 func (m *MemoryStorage) GetPeerByUsername(username string) (*storage.Peer, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	for _, p := range m.peers {
-		if p.Username == username {
-			return &p, nil
-		}
+	id, ok := m.peerUsernames[strings.ToLower(username)]
+	if !ok {
+		return nil, nil
 	}
-	return nil, nil
+	p, ok := m.peers[id]
+	if !ok {
+		return nil, nil
+	}
+	return &p, nil
 }
 
 func (m *MemoryStorage) LoadPeers() ([]*storage.Peer, error) {
@@ -176,6 +191,9 @@ func (m *MemoryStorage) LoadPeers() ([]*storage.Peer, error) {
 func (m *MemoryStorage) DeletePeer(id int64) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if old, ok := m.peers[id]; ok && old.Username != "" {
+		delete(m.peerUsernames, strings.ToLower(old.Username))
+	}
 	delete(m.peers, id)
 	return nil
 }

--- a/telegram/resolve_peer.go
+++ b/telegram/resolve_peer.go
@@ -159,7 +159,7 @@ func (c *Client) resolveAndCache(result *tg.ContactsResolvedPeer) {
 		if user.AccessHash != 0 {
 			c.CachePeer(user.ID, &tg.InputPeerUser{UserID: user.ID, AccessHash: user.AccessHash})
 			if user.Username != "" {
-				c.cacheUsernameLocked(user.Username, user.ID)
+				c.cacheUsername(user.Username, user.ID)
 			}
 		}
 	}
@@ -171,7 +171,7 @@ func (c *Client) resolveAndCache(result *tg.ContactsResolvedPeer) {
 		if channel.AccessHash != 0 {
 			c.CachePeer(channel.ID, &tg.InputPeerChannel{ChannelID: channel.ID, AccessHash: channel.AccessHash})
 			if channel.Username != "" {
-				c.cacheUsernameLocked(channel.Username, channel.ID)
+				c.cacheUsername(channel.Username, channel.ID)
 			}
 		}
 	}
@@ -200,7 +200,7 @@ func (c *Client) ResolvePhone(ctx context.Context, phone string) (tg.InputPeerCl
 	c.Log.Debug("ResolvePhone")
 	return c.resolveCoalescer.Do("phone:"+phone, func() (tg.InputPeerClass, error) {
 		rpc := c.Raw()
-		result, err := rpc.ContactsResolvePhone(context.Background(), &tg.ContactsResolvePhoneRequest{
+		result, err := rpc.ContactsResolvePhone(ctx, &tg.ContactsResolvePhoneRequest{
 			Phone: phone,
 		})
 		if err != nil {

--- a/telegram/transport_adapter.go
+++ b/telegram/transport_adapter.go
@@ -67,3 +67,10 @@ func (s *sessionTransport) SetWriteDeadline(t time.Time) error {
 	}
 	return nil
 }
+
+func (s *sessionTransport) SetReadDeadline(t time.Time) error {
+	if s.conn != nil {
+		return s.conn.SetReadDeadline(t)
+	}
+	return nil
+}


### PR DESCRIPTION
## Performance Review Results

Broad architecture review with 3 parallel agents: allocations, I/O/concurrency, algorithms/caching.

## Fixes (10 issues, 0 P0 + 5 P1 + 3 P2 + 2 P3 remaining from review)

### P0 — Latency
- **Client.mu during I/O dial** — `connectTransport()` now snapshots config under brief lock, does all network I/O lock-free, then publishes session under brief lock. Eliminates 5-30s blocking of all concurrent operations.

### P0 — Allocations
- **Transport read buffer reuse** — `TCPIntermediate`, `TCPFull`, `obfsConn` now reuse `readBuf` across Recv calls. Eliminates ~1MB alloc per packet + per-call 4-byte allocs (stack allocated `[4]byte`).

### P1 — Correctness
- **cacheUsernameLocked data race** — added `peerCacheMu.Lock()` inside function. Was mutating maps without any lock.
- **deliverResult silent drop** — blocking send with 5s timeout instead of `select/default` discard.
- **Retry backoff** — exponential 100ms→2s backoff in Invoke/InvokeRaw (was tight loop).
- **Writer goroutine drain** — drains pending `sendCh` jobs on write error exit.
- **ResolvePhone context** — propagates caller context to RPC.
- **Transport read deadline** — `2 * pingInterval` deadline on Recv to detect silent disconnects.

### P2 — Contention
- **Dispatcher RLock** — fast path uses `RLock` with double-check upgrade. Was exclusive `Lock` per update.
- **MemoryStorage username index** — O(1) map lookup instead of O(n) scan.

## Test Results
- `go build ./...` ✅
- `go test ./... -count=1` ✅
- `go test ./... -race -count=1` ✅

## Remaining (not in this PR)
- P2: Per-packet heap alloc in WebSocket transport
- P2: Unbounded upload goroutines (semaphore limits concurrency but all created eagerly)
- P2: Dedup eviction is random not FIFO
- P2: Peer cache eviction leaks backing array
- P3: Various minor issues (see full review)