### PR TITLE
fix: resolve all remaining concurrency and correctness issues

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -66,10 +66,15 @@ type globalHousekeeper struct {
 	mu       sync.Mutex
 	sessions map[*Session]struct{}
 	once     sync.Once
+	stopCh   chan struct{}
+	stopped  bool
 }
 
 func newGlobalHousekeeper() *globalHousekeeper {
-	return &globalHousekeeper{sessions: make(map[*Session]struct{})}
+	return &globalHousekeeper{
+		sessions: make(map[*Session]struct{}),
+		stopCh:   make(chan struct{}),
+	}
 }
 
 func (h *globalHousekeeper) register(s *Session) {
@@ -84,6 +89,10 @@ func (h *globalHousekeeper) register(s *Session) {
 func (h *globalHousekeeper) unregister(s *Session) {
 	h.mu.Lock()
 	delete(h.sessions, s)
+	if len(h.sessions) == 0 && !h.stopped {
+		h.stopped = true
+		close(h.stopCh)
+	}
 	h.mu.Unlock()
 }
 
@@ -113,6 +122,8 @@ func (h *globalHousekeeper) run() {
 
 	for {
 		select {
+		case <-h.stopCh:
+			return
 		case <-ticker.C:
 			now := time.Now()
 			for _, s := range h.snapshot() {
@@ -216,6 +227,8 @@ type Session struct {
 	mu sync.RWMutex
 	// stopOnce ensures cancel is closed exactly once.
 	stopOnce sync.Once
+	// wg tracks all goroutines spawned by start so Stop can wait for them.
+	wg sync.WaitGroup
 	// cancel is closed to signal background workers to stop.
 	cancel chan struct{}
 
@@ -598,6 +611,7 @@ func (s *Session) handlePacket(msgID int64, seqNo uint32, body tg.TLObject) {
 	if gz, ok := body.(*tg.GzipPacked); ok {
 		decoded, err := gz.Decode()
 		if err != nil {
+			log.Printf("session: gzip decode failed: %v", err)
 			return
 		}
 		obj = decoded
@@ -624,6 +638,7 @@ func (s *Session) handlePacket(msgID int64, seqNo uint32, body tg.TLObject) {
 		if gz, ok := result.(*tg.GzipPacked); ok {
 			decoded, err := gz.Decode()
 			if err != nil {
+				log.Printf("session: gzip decode rpc result failed: %v", err)
 				return
 			}
 			result = decoded
@@ -708,6 +723,11 @@ func (s *Session) SendRaw(ctx context.Context, msgID int64, seqNo uint32, bodyBy
 	select {
 	case s.sendCh <- job:
 		writeTimer.Stop()
+	case <-ctx.Done():
+		writeTimer.Stop()
+		putSendJob(job)
+		s.unregisterRawResult(msgID)
+		return nil, ctx.Err()
 	case <-writeTimer.C:
 		putSendJob(job)
 		s.unregisterRawResult(msgID)
@@ -898,9 +918,12 @@ func (s *Session) start(loopCtx, pingCtx context.Context) error {
 	s.receiveErr = make(chan error, 1)
 	s.connected.Store(true)
 
+	s.wg.Add(1)
 	go s.writer()
 	s.startDispatchWorkers(loopCtx, s.dispatchWorkers)
+	s.wg.Add(1)
 	go func() {
+		defer s.wg.Done()
 		s.receiveErr <- s.receiveLoop(loopCtx)
 	}()
 
@@ -958,6 +981,16 @@ func (s *Session) Stop() {
 	s.mu.RUnlock()
 	if tp != nil {
 		tp.Close()
+	}
+	done := make(chan struct{})
+	go func() {
+		s.wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		log.Printf("session: Stop: timed out waiting for goroutines to exit")
 	}
 }
 
@@ -1045,6 +1078,7 @@ func (s *Session) flushAcks() {
 }
 
 func (s *Session) writer() {
+	defer s.wg.Done()
 	for {
 		select {
 		case <-s.cancel:
@@ -1091,11 +1125,13 @@ func (s *Session) startDispatchWorkers(ctx context.Context, workers int) {
 		workers = 1
 	}
 	for range workers {
+		s.wg.Add(1)
 		go s.dispatchWorker(ctx)
 	}
 }
 
 func (s *Session) dispatchWorker(ctx context.Context) {
+	defer s.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():
@@ -1125,6 +1161,7 @@ func (s *Session) dispatchRaw(raw *tg.MTProtoMessageRaw) {
 	defer tg.ReleaseReader(bodyReader)
 	body, err := tg.ReadTLObject(bodyReader)
 	if err != nil {
+		log.Printf("session: TL decode failed: %v", err)
 		return
 	}
 	s.processIncoming(&tg.MTProtoMessage{MsgID: raw.MsgID, SeqNo: raw.SeqNo, Body: body})

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -278,9 +278,14 @@ func startTestWorkers(s *Session) {
 	s.sendCh = make(chan *sendJob, 64)
 	s.dispatchCh = make(chan *tg.MTProtoMessageRaw, s.dispatchQueueSize)
 	s.connected.Store(true)
+	s.wg.Add(1)
 	go s.writer()
 	s.startDispatchWorkers(context.Background(), 1)
-	go func() { _ = s.receiveLoop(context.Background()) }()
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		_ = s.receiveLoop(context.Background())
+	}()
 }
 
 func TestSessionDispatchConfigDefaults(t *testing.T) {

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -827,6 +827,7 @@ func (c *Client) Start() error {
 }
 
 func (c *Client) Stop() {
+	unregisterClient(c)
 	c.mu.Lock()
 	if c.stopCh == nil {
 		c.stopCh = make(chan struct{})
@@ -2116,8 +2117,10 @@ func (c *Client) evictOldestPeerLocked() {
 	}
 	for len(c.peerCache) > limit && len(c.peerCacheOrder) > 0 {
 		oldest := c.peerCacheOrder[0]
-		c.peerCacheOrder = c.peerCacheOrder[1:]
 		delete(c.peerCache, oldest)
+		copy(c.peerCacheOrder, c.peerCacheOrder[1:])
+		c.peerCacheOrder[len(c.peerCacheOrder)-1] = 0
+		c.peerCacheOrder = c.peerCacheOrder[:len(c.peerCacheOrder)-1]
 	}
 }
 
@@ -2134,8 +2137,10 @@ func (c *Client) cacheUsername(username string, userID int64) {
 	}
 	for len(c.usernameCache) > limit && len(c.usernameCacheOrder) > 0 {
 		oldest := c.usernameCacheOrder[0]
-		c.usernameCacheOrder = c.usernameCacheOrder[1:]
 		delete(c.usernameCache, oldest)
+		copy(c.usernameCacheOrder, c.usernameCacheOrder[1:])
+		c.usernameCacheOrder[len(c.usernameCacheOrder)-1] = ""
+		c.usernameCacheOrder = c.usernameCacheOrder[:len(c.usernameCacheOrder)-1]
 	}
 }
 

--- a/telegram/compose.go
+++ b/telegram/compose.go
@@ -16,6 +16,19 @@ func registerClient(c *Client) {
 	globalClientsMu.Unlock()
 }
 
+func unregisterClient(c *Client) {
+	globalClientsMu.Lock()
+	for i, cl := range globalClients {
+		if cl == c {
+			globalClients[i] = globalClients[len(globalClients)-1]
+			globalClients[len(globalClients)-1] = nil
+			globalClients = globalClients[:len(globalClients)-1]
+			break
+		}
+	}
+	globalClientsMu.Unlock()
+}
+
 // Idle blocks the calling goroutine until all registered clients have been
 // stopped. This is the package-level equivalent of calling Client.Idle() on
 // every active client.

--- a/telegram/logger.go
+++ b/telegram/logger.go
@@ -60,11 +60,9 @@ var (
 // It supports concurrent use, file output with automatic rotation, and prefix
 // chaining via Clone for subsystem-scoped loggers (e.g. "session", "auth").
 type Logger struct {
-	mu     sync.Mutex
-	prefix string
-	// level controls the minimum severity that will be emitted. Set via
-	// SetLevel. Messages at or above this level are printed; those below are
-	// silently discarded. NoLevel (the default) disables all output.
+	mu       sync.Mutex
+	rotateMu *sync.Mutex
+	prefix   string
 	level    atomic.Int32
 	noColor  atomic.Int32
 	output   *log.Logger
@@ -85,9 +83,10 @@ type Logger struct {
 //   - *Logger ready for use (level defaults to NoLevel).
 func NewLogger(prefix string) *Logger {
 	l := &Logger{
-		prefix:  prefix,
-		output:  log.New(os.Stderr, "", 0),
-		maxSize: defaultMaxSize,
+		prefix:   prefix,
+		output:   log.New(os.Stderr, "", 0),
+		maxSize:  defaultMaxSize,
+		rotateMu: &sync.Mutex{},
 	}
 	l.level.Store(int32(NoLevel))
 	return l
@@ -206,6 +205,7 @@ func (l *Logger) Clone(prefix string) *Logger {
 		prefix:   l.prefix + " " + prefix,
 		filePath: l.filePath,
 		maxSize:  l.maxSize,
+		rotateMu: l.rotateMu,
 	}
 	cloned.level.Store(l.level.Load())
 	cloned.noColor.Store(l.noColor.Load())
@@ -237,6 +237,8 @@ func (l *Logger) maybeRotate() {
 	if l.filePath == "" || l.file == nil || l.maxSize <= 0 {
 		return
 	}
+	l.rotateMu.Lock()
+	defer l.rotateMu.Unlock()
 	info, err := l.file.Stat()
 	if err != nil {
 		return

--- a/telegram/memory_storage.go
+++ b/telegram/memory_storage.go
@@ -8,9 +8,15 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/mtgo-labs/mtgo/internal/storage"
 )
+
+type dedupEntry struct {
+	key string
+	ts  time.Time
+}
 
 // MemoryStorage implements the storage interface with in-memory maps, suitable for testing
 // and ephemeral sessions. It stores peers, DC auth entries, update states, and deduplication
@@ -47,7 +53,8 @@ type MemoryStorage struct {
 	dcAuths        map[int]storage.DCAuthEntry
 	updateStates   map[string]storage.UpdateState
 	channelStates  map[string]map[int64]storage.ChannelUpdateState
-	updateDedup    map[string]map[string]struct{}
+	updateDedup    map[string]map[string]time.Time
+	dedupOrder     map[string][]string
 	durableUpdates map[string]map[string]storage.DurableUpdate
 }
 
@@ -66,7 +73,8 @@ func NewMemoryStorage() *MemoryStorage {
 		dcAuths:        make(map[int]storage.DCAuthEntry),
 		updateStates:   make(map[string]storage.UpdateState),
 		channelStates:  make(map[string]map[int64]storage.ChannelUpdateState),
-		updateDedup:    make(map[string]map[string]struct{}),
+		updateDedup:    make(map[string]map[string]time.Time),
+		dedupOrder:     make(map[string][]string),
 		durableUpdates: make(map[string]map[string]storage.DurableUpdate),
 	}
 }
@@ -267,35 +275,51 @@ func (m *MemoryStorage) SaveChannelUpdateState(state *storage.ChannelUpdateState
 // to prevent unbounded growth in long-running processes.
 const maxDedupKeysPerSession = 10000
 
+// dedupExpiry is the maximum age of a dedup key before it is eligible for
+// timestamp-based eviction.
+const dedupExpiry = 30 * time.Minute
+
 func (m *MemoryStorage) SaveUpdateDedupKey(sessionID string, key string) (bool, error) {
 	set := m.updateDedup[sessionID]
 	if set == nil {
-		set = make(map[string]struct{})
+		set = make(map[string]time.Time)
 		m.updateDedup[sessionID] = set
+		m.dedupOrder[sessionID] = nil
 	}
 	if _, ok := set[key]; ok {
 		return false, nil
 	}
 	if len(set) >= maxDedupKeysPerSession {
-		// Evict oldest half to prevent unbounded growth; map iteration
-		// order is non-deterministic but provides approximate oldest-first
-		// behavior for a fixed-capacity dedup set.
+		order := m.dedupOrder[sessionID]
+		now := time.Now()
 		half := maxDedupKeysPerSession / 2
 		cleared := 0
-		for k := range set {
-			delete(set, k)
+		for len(order) > 0 && cleared < half {
+			oldest := order[0]
+			order = order[1:]
+			ts, ok := set[oldest]
+			if !ok {
+				continue
+			}
+			delete(set, oldest)
 			cleared++
-			if cleared >= half {
+			if now.Sub(ts) < dedupExpiry && cleared >= 1 {
 				break
 			}
 		}
+		m.dedupOrder[sessionID] = order
 	}
-	set[key] = struct{}{}
+	set[key] = time.Now()
+	m.dedupOrder[sessionID] = append(m.dedupOrder[sessionID], key)
 	return true, nil
 }
 
 func (m *MemoryStorage) UpdateDedupKeyExists(sessionID string, key string) (bool, error) {
-	_, ok := m.updateDedup[sessionID][key]
+	_, ok := m.updateDedup[sessionID]
+	if !ok {
+		return false, nil
+	}
+	_, ok = m.updateDedup[sessionID][key]
 	return ok, nil
 }
 

--- a/telegram/reconnect.go
+++ b/telegram/reconnect.go
@@ -265,6 +265,11 @@ func (rm *reconnectManager) Attempts() int {
 
 func (rm *reconnectManager) loop(ctx context.Context) {
 	defer close(rm.done)
+	timer := time.NewTimer(0)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
 	for {
 		rm.mu.Lock()
 		rm.attempts++
@@ -284,10 +289,14 @@ func (rm *reconnectManager) loop(ctx context.Context) {
 		delay := rm.cfg.delay(attempt)
 		rm.client.Log.Infof("reconnect attempt %d in %v", attempt, delay)
 
+		timer.Reset(delay)
 		select {
 		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
 			return
-		case <-time.After(delay):
+		case <-timer.C:
 		}
 
 		select {

--- a/telegram/upload.go
+++ b/telegram/upload.go
@@ -330,15 +330,84 @@ func uploadFileKnownRPC(ctx context.Context, rpc *tg.RPCClient, reader io.Reader
 		md5Hash = md5.New()
 	}
 
+	type uploadJob struct {
+		partIdx int32
+		data    []byte
+		bufPtr  *[]byte
+	}
 	type partResult struct {
 		index int32
 		err   error
 	}
 
-	sem := make(chan struct{}, workers)
+	jobs := make(chan uploadJob, workers)
 	results := make(chan partResult, totalParts)
 	var wg sync.WaitGroup
 	var hasErr atomic.Bool
+
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					results <- partResult{err: fmt.Errorf("upload part panic: %v", r)}
+					hasErr.Store(true)
+				}
+			}()
+			for job := range jobs {
+				if hasErr.Load() {
+					uploadBufPool.Put(job.bufPtr)
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					uploadBufPool.Put(job.bufPtr)
+					results <- partResult{index: job.partIdx, err: ctx.Err()}
+					hasErr.Store(true)
+					continue
+				default:
+				}
+
+				var uploadErr error
+				if isBig {
+					_, uploadErr = rpc.UploadSaveBigFilePart(ctx, &tg.UploadSaveBigFilePartRequest{
+						FileID:         fileID,
+						FilePart:       job.partIdx,
+						FileTotalParts: totalParts,
+						Bytes:          job.data,
+					})
+				} else {
+					_, uploadErr = rpc.UploadSaveFilePart(ctx, &tg.UploadSaveFilePartRequest{
+						FileID:   fileID,
+						FilePart: job.partIdx,
+						Bytes:    job.data,
+					})
+				}
+
+				uploadBufPool.Put(job.bufPtr)
+
+				if uploadErr != nil {
+					results <- partResult{index: job.partIdx, err: uploadErr}
+					hasErr.Store(true)
+					continue
+				}
+
+				results <- partResult{index: job.partIdx}
+
+				if opts != nil && opts.Progress != nil {
+					done := min(int64(job.partIdx+1)*uploadPartSize, fileSize)
+					opts.Progress(params.ProgressInfo{
+						FileName:      fileName,
+						TotalBytes:    fileSize,
+						UploadedBytes: done,
+						IsUpload:      true,
+					})
+				}
+			}
+		}()
+	}
 
 	for i := int32(0); i < totalParts; i++ {
 		if hasErr.Load() {
@@ -348,7 +417,7 @@ func uploadFileKnownRPC(ctx context.Context, rpc *tg.RPCClient, reader io.Reader
 		bufPtr := uploadBufPool.Get().(*[]byte)
 		n, readErr := io.ReadFull(reader, *bufPtr)
 		if readErr != nil && readErr != io.ErrUnexpectedEOF && readErr != io.EOF {
-			close(sem)
+			close(jobs)
 			wg.Wait()
 			return nil, 0, fmt.Errorf("upload: read part %d: %w", i, readErr)
 		}
@@ -362,68 +431,10 @@ func uploadFileKnownRPC(ctx context.Context, rpc *tg.RPCClient, reader io.Reader
 			md5Hash.Write(data)
 		}
 
-		wg.Add(1)
-		sem <- struct{}{}
-
-		go func(partIdx int32, data []byte, bufPtr *[]byte) {
-			defer wg.Done()
-			defer func() { <-sem }()
-			defer uploadBufPool.Put(bufPtr)
-			defer func() {
-				if r := recover(); r != nil {
-					results <- partResult{index: partIdx, err: fmt.Errorf("upload part panic: %v", r)}
-					hasErr.Store(true)
-				}
-			}()
-
-			if hasErr.Load() {
-				return
-			}
-
-			select {
-			case <-ctx.Done():
-				results <- partResult{index: partIdx, err: ctx.Err()}
-				hasErr.Store(true)
-				return
-			default:
-			}
-
-			var uploadErr error
-			if isBig {
-				_, uploadErr = rpc.UploadSaveBigFilePart(ctx, &tg.UploadSaveBigFilePartRequest{
-					FileID:         fileID,
-					FilePart:       partIdx,
-					FileTotalParts: totalParts,
-					Bytes:          data,
-				})
-			} else {
-				_, uploadErr = rpc.UploadSaveFilePart(ctx, &tg.UploadSaveFilePartRequest{
-					FileID:   fileID,
-					FilePart: partIdx,
-					Bytes:    data,
-				})
-			}
-
-			if uploadErr != nil {
-				results <- partResult{index: partIdx, err: uploadErr}
-				hasErr.Store(true)
-				return
-			}
-
-			results <- partResult{index: partIdx}
-
-			if opts != nil && opts.Progress != nil {
-				done := min(int64(partIdx+1)*uploadPartSize, fileSize)
-				opts.Progress(params.ProgressInfo{
-					FileName:      fileName,
-					TotalBytes:    fileSize,
-					UploadedBytes: done,
-					IsUpload:      true,
-				})
-			}
-		}(i, data, bufPtr)
+		jobs <- uploadJob{partIdx: i, data: data, bufPtr: bufPtr}
 	}
 
+	close(jobs)
 	wg.Wait()
 	close(results)
 


### PR DESCRIPTION
## Remaining fixes from concurrency audit

10 issues resolved — all P2/P3 items from the 5-agent parallel audit.

### Session
- **WaitGroup on Stop()** — writer/receiveLoop/dispatchWorkers now joined with 10s timeout
- **SendRaw ctx.Done()** — cancelled contexts no longer block for full timeout
- **Gzip/TL decode errors** — logged instead of silently swallowed
- **globalHousekeeper stops** — goroutine exits when all sessions unregistered

### Upload
- **Worker pool** — fixed `workers` goroutines instead of 1-per-part (eliminates 4000+ goroutine spawn for large files)

### Storage
- **FIFO dedup eviction** — ordered eviction + 30min age-based expiry instead of random
- **Peer cache backing array** — copy+shift instead of re-slice leak

### Client
- **unregisterClient** — removes from globalClients on Stop()
- **Logger rotation** — shared mutex across cloned loggers

### Reconnect
- **time.NewTimer** — reuse timer across iterations instead of allocating per retry

All verified: `go test ./... -race -count=1` ✅