### PR TITLE
fix: security audit findings — crypto, concurrency, protocol hardening

### DIFF
--- a/internal/crypto/aes.go
+++ b/internal/crypto/aes.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/aes"
 	"crypto/cipher"
+	"fmt"
 	"sync"
 )
 
@@ -31,6 +32,9 @@ func ReleaseAESBuf(buf []byte) {
 	if buf == nil {
 		return
 	}
+	for i := range buf {
+		buf[i] = 0
+	}
 	igeBufPool.Put(&buf)
 }
 
@@ -45,12 +49,12 @@ func xorInPlace(dst, a, b []byte) {
 // and goroutine-safe, callers should cache the block at the session level
 // (e.g. in Session.SetAuthKey) and pass it through to IGEEncrypt/IGEDecrypt
 // instead of passing the raw key.
-func newAESBlock(key []byte) cipher.Block {
+func newAESBlock(key []byte) (cipher.Block, error) {
 	block, err := aes.NewCipher(key)
 	if err != nil {
-		panic("crypto/aes: " + err.Error())
+		return nil, err
 	}
-	return block
+	return block, nil
 }
 
 // IGEEncrypt encrypts data using AES-256 in Infinite Garble Extension (IGE)
@@ -60,14 +64,17 @@ func newAESBlock(key []byte) cipher.Block {
 // the returned buffer is no longer needed.
 //
 // See https://core.telegram.org/mtproto/description#encrypted-message.
-func IGEEncrypt(data, key, iv []byte) []byte {
+func IGEEncrypt(data, key, iv []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	if len(data)%16 != 0 {
-		panic("crypto/aes: IGE data length must be multiple of 16")
+		return nil, fmt.Errorf("crypto/aes: IGE data length %d is not a multiple of 16", len(data))
 	}
-	block := newAESBlock(key)
+	block, err := newAESBlock(key)
+	if err != nil {
+		return nil, err
+	}
 	var iv1Buf, iv2Buf [16]byte
 	iv1 := iv1Buf[:]
 	iv2 := iv2Buf[:]
@@ -84,7 +91,7 @@ func IGEEncrypt(data, key, iv []byte) []byte {
 		iv1 = result[i : i+16]
 		iv2 = chunk
 	}
-	return result
+	return result, nil
 }
 
 // IGEDecrypt decrypts data using AES-256 in Infinite Garble Extension (IGE)
@@ -94,14 +101,17 @@ func IGEEncrypt(data, key, iv []byte) []byte {
 // the returned buffer is no longer needed.
 //
 // See https://core.telegram.org/mtproto/description#encrypted-message.
-func IGEDecrypt(data, key, iv []byte) []byte {
+func IGEDecrypt(data, key, iv []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, nil
 	}
 	if len(data)%16 != 0 {
-		panic("crypto/aes: IGE data length must be multiple of 16")
+		return nil, fmt.Errorf("crypto/aes: IGE data length %d is not a multiple of 16", len(data))
 	}
-	block := newAESBlock(key)
+	block, err := newAESBlock(key)
+	if err != nil {
+		return nil, err
+	}
 	var iv1Buf, iv2Buf [16]byte
 	iv1 := iv1Buf[:]
 	iv2 := iv2Buf[:]
@@ -118,7 +128,7 @@ func IGEDecrypt(data, key, iv []byte) []byte {
 		iv1 = chunk
 		iv2 = result[i : i+16]
 	}
-	return result
+	return result, nil
 }
 
 func incrementIV(iv []byte) {
@@ -132,21 +142,24 @@ func incrementIV(iv []byte) {
 
 // CTREncrypt encrypts data using AES-256 in counter (CTR) mode with a 16-byte
 // IV that is incremented as a big-endian integer. Returns the encrypted ciphertext.
-func CTREncrypt(data, key, iv []byte) []byte {
+func CTREncrypt(data, key, iv []byte) ([]byte, error) {
 	return ctrCrypt(data, key, iv)
 }
 
 // CTRDecrypt decrypts data using AES-256 in counter (CTR) mode with a 16-byte
 // IV that is incremented as a big-endian integer. Returns the decrypted plaintext.
-func CTRDecrypt(data, key, iv []byte) []byte {
+func CTRDecrypt(data, key, iv []byte) ([]byte, error) {
 	return ctrCrypt(data, key, iv)
 }
 
-func ctrCrypt(data, key, iv []byte) []byte {
+func ctrCrypt(data, key, iv []byte) ([]byte, error) {
 	if len(data) == 0 {
-		return nil
+		return nil, nil
 	}
-	block := newAESBlock(key)
+	block, err := newAESBlock(key)
+	if err != nil {
+		return nil, err
+	}
 
 	ivCopy := make([]byte, 16)
 	copy(ivCopy, iv)
@@ -165,7 +178,7 @@ func ctrCrypt(data, key, iv []byte) []byte {
 			block.Encrypt(keystream[:], ivCopy)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // CTRCipher implements a stateful AES-256 CTR-mode stream cipher that can
@@ -180,8 +193,11 @@ type CTRCipher struct {
 
 // NewCTRCipher creates a new CTRCipher initialized with the given 32-byte key
 // and 16-byte IV. The cipher is ready to process data immediately.
-func NewCTRCipher(key, iv []byte) *CTRCipher {
-	block := newAESBlock(key)
+func NewCTRCipher(key, iv []byte) (*CTRCipher, error) {
+	block, err := newAESBlock(key)
+	if err != nil {
+		return nil, err
+	}
 	ivCopy := make([]byte, 16)
 	copy(ivCopy, iv)
 	c := &CTRCipher{
@@ -189,7 +205,7 @@ func NewCTRCipher(key, iv []byte) *CTRCipher {
 		iv:    ivCopy,
 	}
 	block.Encrypt(c.keystream[:], c.iv)
-	return c
+	return c, nil
 }
 
 // Process XORs data with the CTR keystream, advancing the IV counter and

--- a/internal/crypto/aes_test.go
+++ b/internal/crypto/aes_test.go
@@ -37,7 +37,10 @@ func TestIGE256EncryptDecryptRoundTrip(t *testing.T) {
 	data := []byte("Hello, MTProto world!!")
 	data = append(data, make([]byte, 10)...)
 
-	encrypted := IGEEncrypt(data, key, iv)
+	encrypted, err := IGEEncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if bytes.Equal(encrypted, data) {
 		t.Fatal("encrypted should differ from plaintext")
 	}
@@ -45,21 +48,30 @@ func TestIGE256EncryptDecryptRoundTrip(t *testing.T) {
 		t.Fatalf("encrypted length %d != data length %d", len(encrypted), len(data))
 	}
 
-	decrypted := IGEDecrypt(encrypted, key, iv)
+	decrypted, err := IGEDecrypt(encrypted, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(decrypted, data) {
 		t.Fatalf("round-trip failed:\n  want %x\n  got  %x", data, decrypted)
 	}
 }
 
 func TestIGEEncryptEmpty(t *testing.T) {
-	encrypted := IGEEncrypt([]byte{}, make([]byte, 32), make([]byte, 32))
+	encrypted, err := IGEEncrypt([]byte{}, make([]byte, 32), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(encrypted) != 0 {
 		t.Fatalf("expected empty, got %d bytes", len(encrypted))
 	}
 }
 
 func TestIGEDecryptEmpty(t *testing.T) {
-	decrypted := IGEDecrypt([]byte{}, make([]byte, 32), make([]byte, 32))
+	decrypted, err := IGEDecrypt([]byte{}, make([]byte, 32), make([]byte, 32))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(decrypted) != 0 {
 		t.Fatalf("expected empty, got %d bytes", len(decrypted))
 	}
@@ -70,34 +82,39 @@ func TestIGE256KnownVector(t *testing.T) {
 	iv := make([]byte, 32)
 	data := make([]byte, 16)
 
-	encrypted := IGEEncrypt(data, key, iv)
-	decrypted := IGEDecrypt(encrypted, key, iv)
+	encrypted, err := IGEEncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decrypted, err := IGEDecrypt(encrypted, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(decrypted, data) {
 		t.Fatal("known vector round-trip failed")
 	}
 
-	encrypted2 := IGEEncrypt(data, key, iv)
+	encrypted2, err := IGEEncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(encrypted, encrypted2) {
 		t.Fatal("encryption should be deterministic")
 	}
 }
 
 func TestIGEInvalidKeyLength(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for invalid key size")
-		}
-	}()
-	IGEEncrypt(make([]byte, 16), make([]byte, 15), make([]byte, 32))
+	_, err := IGEEncrypt(make([]byte, 16), make([]byte, 15), make([]byte, 32))
+	if err == nil {
+		t.Fatal("expected error for invalid key size")
+	}
 }
 
 func TestIGEInvalidDataLength(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatal("expected panic for non-aligned data")
-		}
-	}()
-	IGEEncrypt(make([]byte, 17), make([]byte, 32), make([]byte, 32))
+	_, err := IGEEncrypt(make([]byte, 17), make([]byte, 32), make([]byte, 32))
+	if err == nil {
+		t.Fatal("expected error for non-aligned data")
+	}
 }
 
 func TestCTREncryptDecryptRoundTrip(t *testing.T) {
@@ -111,7 +128,10 @@ func TestCTREncryptDecryptRoundTrip(t *testing.T) {
 	}
 	data := []byte("CTR mode test data for MTProto obfuscated transport")
 
-	encrypted := CTREncrypt(data, key, iv)
+	encrypted, err := CTREncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if bytes.Equal(encrypted, data) {
 		t.Fatal("encrypted should differ from plaintext")
 	}
@@ -119,14 +139,20 @@ func TestCTREncryptDecryptRoundTrip(t *testing.T) {
 		t.Fatalf("CTR should preserve length: %d != %d", len(encrypted), len(data))
 	}
 
-	decrypted := CTRDecrypt(encrypted, key, iv)
+	decrypted, err := CTRDecrypt(encrypted, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(decrypted, data) {
 		t.Fatalf("CTR round-trip failed:\n  want %x\n  got  %x", data, decrypted)
 	}
 }
 
 func TestCTREmpty(t *testing.T) {
-	got := CTREncrypt([]byte{}, make([]byte, 32), make([]byte, 16))
+	got, err := CTREncrypt([]byte{}, make([]byte, 32), make([]byte, 16))
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(got) != 0 {
 		t.Fatalf("expected empty, got %d bytes", len(got))
 	}
@@ -137,8 +163,14 @@ func TestCTRDeterministic(t *testing.T) {
 	iv := make([]byte, 16)
 	data := []byte("deterministic test")
 
-	e1 := CTREncrypt(data, key, iv)
-	e2 := CTREncrypt(data, key, iv)
+	e1, err := CTREncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e2, err := CTREncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !bytes.Equal(e1, e2) {
 		t.Fatal("CTR encrypt should be deterministic with same key/iv")
 	}
@@ -152,9 +184,15 @@ func TestCTRCipherStateful(t *testing.T) {
 	}
 	data := []byte("12345678901234567890123456789012")
 
-	allEncrypted := CTREncrypt(data, key, iv)
+	allEncrypted, err := CTREncrypt(data, key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	enc := NewCTRCipher(key, iv)
+	enc, err := NewCTRCipher(key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	part1 := enc.Process(data[:16])
 	part2 := enc.Process(data[16:])
 
@@ -171,11 +209,17 @@ func TestCTRCipherRoundTrip(t *testing.T) {
 		key[i] = byte(i)
 	}
 
-	enc := NewCTRCipher(key, iv)
+	enc, err := NewCTRCipher(key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	data := []byte("stateful cipher test data!")
 	encrypted := enc.Process(data)
 
-	dec := NewCTRCipher(key, iv)
+	dec, err := NewCTRCipher(key, iv)
+	if err != nil {
+		t.Fatal(err)
+	}
 	decrypted := dec.Process(encrypted)
 
 	if !bytes.Equal(decrypted, data) {

--- a/internal/crypto/mtproto.go
+++ b/internal/crypto/mtproto.go
@@ -57,7 +57,7 @@ func KDF(authKey, msgKey []byte, outgoing bool) (aesKey, aesIV [32]byte) {
 // via KDF, encrypts with AES-IGE, and returns authKeyID + msgKey + ciphertext.
 //
 // See https://core.telegram.org/mtproto/description#encrypted-message.
-func Pack(message *tg.MTProtoMessage, salt int64, sessionID []byte, authKey, authKeyID []byte) []byte {
+func Pack(message *tg.MTProtoMessage, salt int64, sessionID []byte, authKey, authKeyID []byte) ([]byte, error) {
 	dataBuf := bufPool.Get().(*bytes.Buffer)
 	dataBuf.Reset()
 	defer bufPool.Put(dataBuf)
@@ -69,7 +69,7 @@ func Pack(message *tg.MTProtoMessage, salt int64, sessionID []byte, authKey, aut
 	msgBuf.Reset()
 	if err := message.Encode(msgBuf); err != nil {
 		bufPool.Put(msgBuf)
-		panic("crypto/mtproto: " + err.Error())
+		return nil, fmt.Errorf("crypto/mtproto: %w", err)
 	}
 	dataBuf.Write(msgBuf.Bytes())
 	bufPool.Put(msgBuf)
@@ -92,7 +92,10 @@ func Pack(message *tg.MTProtoMessage, salt int64, sessionID []byte, authKey, aut
 	msgKey := msgKeyLarge[8:24]
 
 	keyArr, ivArr := KDF(authKey, msgKey, true)
-	encrypted := IGEEncrypt(data, keyArr[:], ivArr[:])
+	encrypted, err := IGEEncrypt(data, keyArr[:], ivArr[:])
+	if err != nil {
+		return nil, err
+	}
 
 	result := bufPool.Get().(*bytes.Buffer)
 	result.Reset()
@@ -104,14 +107,14 @@ func Pack(message *tg.MTProtoMessage, salt int64, sessionID []byte, authKey, aut
 	out := make([]byte, result.Len())
 	copy(out, result.Bytes())
 	bufPool.Put(result)
-	return out
+	return out, nil
 }
 
 // PackRaw is like [Pack] but accepts pre-serialized body bytes instead of a
 // *tg.MTProtoMessage. It manually writes the MTProto envelope (msgID, seqNo,
 // body length prefix) followed by bodyBytes, then applies padding, msgKey
 // computation, and AES-IGE encryption identically to [Pack].
-func PackRaw(msgID int64, seqNo uint32, bodyBytes []byte, salt int64, sessionID, authKey, authKeyID []byte) []byte {
+func PackRaw(msgID int64, seqNo uint32, bodyBytes []byte, salt int64, sessionID, authKey, authKeyID []byte) ([]byte, error) {
 	dataBuf := bufPool.Get().(*bytes.Buffer)
 	dataBuf.Reset()
 	defer bufPool.Put(dataBuf)
@@ -141,7 +144,10 @@ func PackRaw(msgID int64, seqNo uint32, bodyBytes []byte, salt int64, sessionID,
 	msgKey := msgKeyLarge[8:24]
 
 	keyArr, ivArr := KDF(authKey, msgKey, true)
-	encrypted := IGEEncrypt(data, keyArr[:], ivArr[:])
+	encrypted, err := IGEEncrypt(data, keyArr[:], ivArr[:])
+	if err != nil {
+		return nil, err
+	}
 
 	result := bufPool.Get().(*bytes.Buffer)
 	result.Reset()
@@ -153,7 +159,7 @@ func PackRaw(msgID int64, seqNo uint32, bodyBytes []byte, salt int64, sessionID,
 	out := make([]byte, result.Len())
 	copy(out, result.Bytes())
 	bufPool.Put(result)
-	return out
+	return out, nil
 }
 
 // Unpack decrypts and decodes an incoming encrypted message. It verifies
@@ -183,7 +189,10 @@ func Unpack(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTProtoMessa
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "encrypted data not aligned to 16"}
 	}
 
-	decrypted := IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+	decrypted, err := IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if len(decrypted) < 16 {
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "decrypted data too short"}
@@ -248,7 +257,10 @@ func UnpackEnvelope(data []byte, sessionID, authKey, authKeyID []byte) (*tg.MTPr
 		return nil, nil, &tgerr.SecurityCheckMismatch{Name: "encrypted data not aligned to 16"}
 	}
 
-	decrypted := IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+	decrypted, err := IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+	if err != nil {
+		return nil, nil, err
+	}
 
 	if len(decrypted) < 16 {
 		ReleaseAESBuf(decrypted)

--- a/internal/crypto/mtproto_test.go
+++ b/internal/crypto/mtproto_test.go
@@ -80,10 +80,13 @@ func TestPackUnpackRoundTrip(t *testing.T) {
 		Body:  tg.TLBool(true),
 	}
 
-	packed := Pack(msg, salt, sessionID, authKey, authKeyIDBytes)
-	if len(packed) < 24 {
-		t.Fatal("packed data too short")
-	}
+	packed, err := Pack(msg, salt, sessionID, authKey, authKeyIDBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(packed) < 24 {
+			t.Fatal("packed data too short")
+		}
 
 	if !bytes.Equal(packed[:8], authKeyIDBytes) {
 		t.Fatal("auth_key_id mismatch")
@@ -118,13 +121,16 @@ func TestPackUnpackSecurityChecks(t *testing.T) {
 		Body:  tg.TLBool(true),
 	}
 
-	packed := Pack(msg, 0, sessionID, authKey, authKeyIDBytes)
+	packed, err := Pack(msg, 0, sessionID, authKey, authKeyIDBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	tampered := make([]byte, len(packed))
+		tampered := make([]byte, len(packed))
 	copy(tampered, packed)
 	tampered[0] ^= 0xFF
 
-	_, _, err := Unpack(tampered, sessionID, authKey, authKeyIDBytes)
+	_, _, err = Unpack(tampered, sessionID, authKey, authKeyIDBytes)
 	if err == nil {
 		t.Fatal("expected error on auth_key_id mismatch")
 	}
@@ -142,12 +148,15 @@ func TestPackUnpackSessionIDMismatch(t *testing.T) {
 		Body:  tg.TLBool(true),
 	}
 
-	packed := Pack(msg, 0, sessionID, authKey, authKeyIDBytes)
+	packed, err := Pack(msg, 0, sessionID, authKey, authKeyIDBytes)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	wrongSessionID := make([]byte, 8)
+		wrongSessionID := make([]byte, 8)
 	wrongSessionID[0] = 0xFF
 
-	_, _, err := Unpack(packed, wrongSessionID, authKey, authKeyIDBytes)
+	_, _, err = Unpack(packed, wrongSessionID, authKey, authKeyIDBytes)
 	if err == nil {
 		t.Fatal("expected error on session_id mismatch")
 	}

--- a/internal/crypto/rsa.go
+++ b/internal/crypto/rsa.go
@@ -63,7 +63,10 @@ func rsapad(data []byte, n *big.Int) ([]byte, error) {
 		copy(dataWithHash[:], dataPadReversed)
 		copy(dataWithHash[dataWithPaddingLen:], hash[:])
 
-		aesEncrypted := IGEEncrypt(dataWithHash[:], tempKey[:], zeroIV)
+		aesEncrypted, err := IGEEncrypt(dataWithHash[:], tempKey[:], zeroIV)
+			if err != nil {
+				return nil, err
+			}
 
 		aesHash := sha256.Sum256(aesEncrypted)
 		for i := 0; i < tempKeyLen; i++ {

--- a/internal/crypto/secret.go
+++ b/internal/crypto/secret.go
@@ -15,12 +15,9 @@ import (
 )
 
 var (
-	errEmptyPlaintext     = errors.New("crypto/secret: empty plaintext")
-	errCiphertextTooShort = errors.New("crypto/secret: ciphertext too short")
-	errMsgKeyMismatch     = errors.New("crypto/secret: msg_key mismatch")
-	errDecryptedTooShort  = errors.New("crypto/secret: decrypted too short")
-	errInvalidMsgLen      = errors.New("crypto/secret: invalid message length")
-	errFileNotAligned     = errors.New("crypto/secret: encrypted file not aligned to 16")
+	errEmptyPlaintext   = errors.New("crypto/secret: empty plaintext")
+	errDecryptionFailed = errors.New("crypto/secret: decryption failed")
+	errFileNotAligned   = errors.New("crypto/secret: encrypted file not aligned to 16")
 )
 
 const (
@@ -123,7 +120,9 @@ func SecretEncrypt(plaintext, key []byte, outgoing bool) ([]byte, error) {
 		paddingLen += 16 - rem
 	}
 	padding := make([]byte, paddingLen)
-	rand.Read(padding)
+	if _, err := rand.Read(padding); err != nil {
+		return nil, fmt.Errorf("crypto/secret: generate padding: %w", err)
+	}
 	buf.Write(padding)
 
 	data := buf.Bytes()
@@ -146,7 +145,10 @@ func SecretEncrypt(plaintext, key []byte, outgoing bool) ([]byte, error) {
 	msgKey := msgKeyLarge[8:24]
 
 	aesKey, aesIV := secretKDF(key, msgKey, x)
-	encrypted := IGEEncrypt(data, aesKey[:], aesIV[:])
+	encrypted, err := IGEEncrypt(data, aesKey[:], aesIV[:])
+	if err != nil {
+		return nil, err
+	}
 
 	var result bytes.Buffer
 	result.Write(msgKey)
@@ -157,7 +159,7 @@ func SecretEncrypt(plaintext, key []byte, outgoing bool) ([]byte, error) {
 
 func SecretDecrypt(ciphertext, key []byte, outgoing bool) ([]byte, error) {
 	if len(ciphertext) < 16+16 {
-		return nil, errCiphertextTooShort
+		return nil, errDecryptionFailed
 	}
 
 	msgKey := ciphertext[:16]
@@ -169,7 +171,10 @@ func SecretDecrypt(ciphertext, key []byte, outgoing bool) ([]byte, error) {
 	}
 
 	aesKey, aesIV := secretKDF(key, msgKey, x)
-	decrypted := IGEDecrypt(encrypted, aesKey[:], aesIV[:])
+	decrypted, err := IGEDecrypt(encrypted, aesKey[:], aesIV[:])
+	if err != nil {
+		return nil, errDecryptionFailed
+	}
 
 	var stackBuf [4096]byte
 	msgKeyLargeInput := stackBuf[:0]
@@ -182,19 +187,19 @@ func SecretDecrypt(ciphertext, key []byte, outgoing bool) ([]byte, error) {
 	copy(msgKeyLargeInput[32:], decrypted)
 	msgKeyCheck := sha256.Sum256(msgKeyLargeInput)
 	if subtle.ConstantTimeCompare(msgKey, msgKeyCheck[8:24]) != 1 {
-		return nil, errMsgKeyMismatch
+		return nil, errDecryptionFailed
 	}
 
 	if len(decrypted) < 4 {
-		return nil, errDecryptedTooShort
+		return nil, errDecryptionFailed
 	}
 	msgLen := int(binary.LittleEndian.Uint32(decrypted[:4]))
 	if msgLen < 0 || msgLen+4 > len(decrypted) {
-		return nil, errInvalidMsgLen
+		return nil, errDecryptionFailed
 	}
 	paddingLen := len(decrypted) - 4 - msgLen
 	if paddingLen < SecretChatMinPadding || paddingLen > SecretChatMaxPadding {
-		return nil, fmt.Errorf("crypto/secret: invalid padding length %d", paddingLen)
+		return nil, errDecryptionFailed
 	}
 
 	return decrypted[4 : 4+msgLen], nil
@@ -222,7 +227,7 @@ func secretKDF(key, msgKey []byte, x int) (aesKey, aesIV [32]byte) {
 	return aesKey, aesIV
 }
 
-func EncryptFile(data, fileKey, fileIV []byte) []byte {
+func EncryptFile(data, fileKey, fileIV []byte) ([]byte, error) {
 	return IGEEncrypt(padFile(data), fileKey, fileIV)
 }
 
@@ -230,7 +235,7 @@ func DecryptFile(data, fileKey, fileIV []byte) ([]byte, error) {
 	if len(data)%16 != 0 {
 		return nil, errFileNotAligned
 	}
-	return IGEDecrypt(data, fileKey, fileIV), nil
+	return IGEDecrypt(data, fileKey, fileIV)
 }
 
 func FileKeyFingerprint(key, iv []byte) int32 {

--- a/internal/session/auth.go
+++ b/internal/session/auth.go
@@ -114,11 +114,13 @@ func (a *Auth) findKeyFingerprint(fingerprints []int64) (int64, bool) {
 	return 0, false
 }
 
-func (a *Auth) generateRandomBN(bits int) *big.Int {
+func (a *Auth) generateRandomBN(bits int) (*big.Int, error) {
 	b := make([]byte, bits/8)
-	_, _ = rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		return nil, fmt.Errorf("session: generate random: %w", err)
+	}
 	b[0] |= 0x80
-	return new(big.Int).SetBytes(b)
+	return new(big.Int).SetBytes(b), nil
 }
 
 // Create performs the complete MTProto key generation handshake over the
@@ -213,10 +215,13 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 		return nil, ErrDHParamsFail
 	case *tg.ServerDHParamsOk:
 		key, iv := computeKeyAndIV(newNonce[:], resPQ.ServerNonce[:])
-		decrypted := crypto.IGEDecrypt([]byte(v.EncryptedAnswer), key, iv)
-		defer crypto.ReleaseAESBuf(decrypted)
+		decrypted, err := crypto.IGEDecrypt([]byte(v.EncryptedAnswer), key, iv)
+			if err != nil {
+				return nil, fmt.Errorf("step 8: decrypt DH params: %w", err)
+			}
+			defer crypto.ReleaseAESBuf(decrypted)
 
-		serverDHData, err := unwrapDataWithHash(decrypted)
+			serverDHData, err := unwrapDataWithHash(decrypted)
 		if err != nil {
 			return nil, fmt.Errorf("step 8: unwrap decrypted DH params: %w", err)
 		}
@@ -246,8 +251,10 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 		if dhPrime.BitLen() != 2048 {
 			return nil, fmt.Errorf("%w: bit length %d", ErrDHPrimeInvalid, dhPrime.BitLen())
 		}
-		if !dhPrime.ProbablyPrime(20) {
-			return nil, ErrDHPrimeInvalid
+		if dhPrime.Cmp(crypto.CurrentDHPrime) != 0 {
+			if !dhPrime.ProbablyPrime(20) {
+				return nil, ErrDHPrimeInvalid
+			}
 		}
 
 		g := big.NewInt(int64(dhInner.G))
@@ -267,7 +274,17 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 			return nil, ErrGAOutOfRange
 		}
 
-		b := a.generateRandomBN(2048)
+		// B8: verify gA is in the correct subgroup
+		halfPrime := new(big.Int).Rsh(dhPrime, 1)
+		subgroupCheck := new(big.Int).Exp(gA, halfPrime, dhPrime)
+		if subgroupCheck.Cmp(one) != 0 {
+			return nil, ErrGAOutOfRange
+		}
+
+		b, err := a.generateRandomBN(2048)
+		if err != nil {
+			return nil, fmt.Errorf("step 9: generate DH secret: %w", err)
+		}
 		gB := new(big.Int).Exp(g, b, dhPrime)
 
 		two := big.NewInt(2)
@@ -305,8 +322,11 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 			clientDHWithHash = append(clientDHWithHash, pad...)
 		}
 
-		encClientDH := crypto.IGEEncrypt(clientDHWithHash, key, iv)
-		defer crypto.ReleaseAESBuf(encClientDH)
+		encClientDH, err := crypto.IGEEncrypt(clientDHWithHash, key, iv)
+			if err != nil {
+				return nil, fmt.Errorf("step 9: encrypt client DH: %w", err)
+			}
+			defer crypto.ReleaseAESBuf(encClientDH)
 
 		if err := a.sendUnencrypted(conn, &tg.SetClientDHParamsRequest{
 			Nonce:         nonce,
@@ -356,7 +376,11 @@ func (a *Auth) Create(conn authTransport) (*AuthResult, error) {
 				return nil, ErrServerNonceMismatch
 			}
 			retryID = authKeyAuxHash()
-			b = a.generateRandomBN(2048)
+			var retryErr error
+			b, retryErr = a.generateRandomBN(2048)
+			if retryErr != nil {
+				return nil, fmt.Errorf("step 10: retry DH secret: %w", retryErr)
+			}
 			gB = new(big.Int).Exp(g, b, dhPrime)
 			authKey = computeAuthKey(gA, b, dhPrime)
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -529,7 +529,10 @@ func (s *Session) Send(ctx context.Context, msgID int64, seqNo uint32, body tg.T
 		Body:  body,
 	}
 
-	encrypted := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	encrypted, err := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("session: pack message: %w", err)
+	}
 
 	ch := s.registerResult(msgID)
 
@@ -600,7 +603,10 @@ func (s *Session) sendRPCDrop(reqMsgID int64) {
 		SeqNo: uint32(seqNo),
 		Body:  drop,
 	}
-	encrypted := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	encrypted, err := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	if err != nil {
+		return
+	}
 	job := getSendJob()
 	job.encrypted = encrypted
 	job.deadline = time.Now().Add(5 * time.Second)
@@ -717,7 +723,10 @@ func (s *Session) SendRaw(ctx context.Context, msgID int64, seqNo uint32, bodyBy
 		return nil, ErrTransportNotSet
 	}
 
-	encrypted := crypto.PackRaw(msgID, seqNo, bodyBytes, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	encrypted, err := crypto.PackRaw(msgID, seqNo, bodyBytes, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	if err != nil {
+		return nil, fmt.Errorf("session: send raw: %w", err)
+	}
 
 	ch := s.registerRawResult(msgID)
 
@@ -1027,7 +1036,10 @@ func (s *Session) sendServiceMessage(body tg.TLObject) {
 		SeqNo: uint32(seqNo),
 		Body:  body,
 	}
-	encrypted := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	encrypted, err := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), authKey, authKeyID)
+	if err != nil {
+		return
+	}
 	job := getSendJob()
 	job.encrypted = encrypted
 	job.deadline = time.Now().Add(10 * time.Second)

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -237,11 +237,19 @@ func makeEncryptedResponse(s *Session, msgID int64, seqNo uint32, body tg.TLObje
 		SeqNo: seqNo,
 		Body:  body,
 	}
-	return crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), s.authKey, s.authKeyID)
+	encrypted, err := crypto.Pack(message, s.serverSalt.Load(), s.sessionIDBytes(), s.authKey, s.authKeyID)
+	if err != nil {
+		panic("makeEncryptedResponse: " + err.Error())
+	}
+	return encrypted
 }
 
 func makeEncryptedRawResponse(s *Session, msgID int64, seqNo uint32, body []byte) []byte {
-	return crypto.PackRaw(msgID, seqNo, body, s.serverSalt.Load(), s.sessionIDBytes(), s.authKey, s.authKeyID)
+	encrypted, err := crypto.PackRaw(msgID, seqNo, body, s.serverSalt.Load(), s.sessionIDBytes(), s.authKey, s.authKeyID)
+	if err != nil {
+		panic("makeEncryptedRawResponse: " + err.Error())
+	}
+	return encrypted
 }
 
 func encodeTLObject(t *testing.T, obj tg.TLObject) []byte {

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -525,9 +525,8 @@ func NewAdapter(a Adapter) *adapterWrapper {
 	return &adapterWrapper{ext: a}
 }
 
+// load initializes a.sess from the external adapter. Caller must hold a.mu.
 func (a *adapterWrapper) load() error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
 	if a.sess != nil {
 		return nil
 	}
@@ -542,13 +541,14 @@ func (a *adapterWrapper) load() error {
 	return nil
 }
 
+// save persists the current session to the external adapter. Caller must hold a.mu.
 func (a *adapterWrapper) save() error {
-	a.mu.Lock()
-	defer a.mu.Unlock()
 	return a.ext.SaveSession(a.sess)
 }
 
 func (a *adapterWrapper) SessionID() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
@@ -559,26 +559,28 @@ func (a *adapterWrapper) SetSessionID(v string) error {
 		sa.SetSessionName(v)
 	}
 	a.mu.Lock()
+	defer a.mu.Unlock()
 	a.sess = nil
-	a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return fmt.Errorf("load after SetSessionName: %w", err)
 	}
-	a.mu.Lock()
 	a.sess.SessionID = v
-	a.mu.Unlock()
 	if err := a.save(); err != nil {
 		return fmt.Errorf("save session: %w", err)
 	}
 	return nil
 }
 func (a *adapterWrapper) DCID() (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return 0, err
 	}
 	return a.sess.DC, nil
 }
 func (a *adapterWrapper) SetDCID(v int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -586,12 +588,16 @@ func (a *adapterWrapper) SetDCID(v int) error {
 	return a.save()
 }
 func (a *adapterWrapper) APIID() (int32, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return 0, err
 	}
 	return a.sess.APIID, nil
 }
 func (a *adapterWrapper) SetAPIID(v int32) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -599,12 +605,16 @@ func (a *adapterWrapper) SetAPIID(v int32) error {
 	return a.save()
 }
 func (a *adapterWrapper) APIHash() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
 	return a.sess.APIHash, nil
 }
 func (a *adapterWrapper) SetAPIHash(v string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -612,12 +622,16 @@ func (a *adapterWrapper) SetAPIHash(v string) error {
 	return a.save()
 }
 func (a *adapterWrapper) TestMode() (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return false, err
 	}
 	return a.sess.TestMode, nil
 }
 func (a *adapterWrapper) SetTestMode(v bool) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -625,12 +639,16 @@ func (a *adapterWrapper) SetTestMode(v bool) error {
 	return a.save()
 }
 func (a *adapterWrapper) AuthKey() ([]byte, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return nil, err
 	}
 	return a.sess.AuthKey, nil
 }
 func (a *adapterWrapper) SetAuthKey(v []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -638,12 +656,16 @@ func (a *adapterWrapper) SetAuthKey(v []byte) error {
 	return a.save()
 }
 func (a *adapterWrapper) UserID() (int64, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return 0, err
 	}
 	return a.sess.UserID, nil
 }
 func (a *adapterWrapper) SetUserID(v int64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -651,12 +673,16 @@ func (a *adapterWrapper) SetUserID(v int64) error {
 	return a.save()
 }
 func (a *adapterWrapper) IsBot() (bool, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return false, err
 	}
 	return a.sess.IsBot, nil
 }
 func (a *adapterWrapper) SetIsBot(v bool) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -664,12 +690,16 @@ func (a *adapterWrapper) SetIsBot(v bool) error {
 	return a.save()
 }
 func (a *adapterWrapper) FirstName() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
 	return a.sess.FirstName, nil
 }
 func (a *adapterWrapper) SetFirstName(v string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -677,12 +707,16 @@ func (a *adapterWrapper) SetFirstName(v string) error {
 	return a.save()
 }
 func (a *adapterWrapper) LastName() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
 	return a.sess.LastName, nil
 }
 func (a *adapterWrapper) SetLastName(v string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -690,12 +724,16 @@ func (a *adapterWrapper) SetLastName(v string) error {
 	return a.save()
 }
 func (a *adapterWrapper) Username() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
 	return a.sess.Username, nil
 }
 func (a *adapterWrapper) SetUsername(v string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -703,12 +741,16 @@ func (a *adapterWrapper) SetUsername(v string) error {
 	return a.save()
 }
 func (a *adapterWrapper) Date() (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return 0, err
 	}
 	return a.sess.Date, nil
 }
 func (a *adapterWrapper) SetDate(v int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -716,12 +758,16 @@ func (a *adapterWrapper) SetDate(v int) error {
 	return a.save()
 }
 func (a *adapterWrapper) ServerAddress() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}
 	return a.sess.Addr, nil
 }
 func (a *adapterWrapper) SetServerAddress(v string) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -729,12 +775,16 @@ func (a *adapterWrapper) SetServerAddress(v string) error {
 	return a.save()
 }
 func (a *adapterWrapper) Port() (int, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return 0, err
 	}
 	return a.sess.Port, nil
 }
 func (a *adapterWrapper) SetPort(v int) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -742,12 +792,16 @@ func (a *adapterWrapper) SetPort(v int) error {
 	return a.save()
 }
 func (a *adapterWrapper) State() ([]byte, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return nil, err
 	}
 	return a.sess.State, nil
 }
 func (a *adapterWrapper) SetState(v []byte) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return err
 	}
@@ -755,6 +809,8 @@ func (a *adapterWrapper) SetState(v []byte) error {
 	return a.save()
 }
 func (a *adapterWrapper) ExportSessionString() (string, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if err := a.load(); err != nil {
 		return "", err
 	}

--- a/internal/transport/tcp_full.go
+++ b/internal/transport/tcp_full.go
@@ -7,6 +7,7 @@ import (
 	"hash/crc32"
 	"io"
 	"net"
+	"sync/atomic"
 )
 
 type TCPFull struct {
@@ -23,7 +24,7 @@ func NewTCPFull(conn net.Conn) *TCPFull {
 // Connect resets the internal sequence counter. It does not perform any
 // network I/O because the underlying connection is already established.
 func (t *TCPFull) Connect() error {
-	t.seqNo = 0
+	atomic.StoreUint32(&t.seqNo, 0)
 	return nil
 }
 
@@ -35,11 +36,11 @@ func (t *TCPFull) Send(buf *bytes.Buffer) error {
 
 	packet := make([]byte, 4+4+len(data)+4)
 	binary.LittleEndian.PutUint32(packet[0:4], uint32(len(data)+12))
-	binary.LittleEndian.PutUint32(packet[4:8], t.seqNo)
+	binary.LittleEndian.PutUint32(packet[4:8], atomic.LoadUint32(&t.seqNo))
 	copy(packet[8:8+len(data)], data)
 	binary.LittleEndian.PutUint32(packet[8+len(data):], crc32.ChecksumIEEE(packet[:8+len(data)]))
 
-	t.seqNo++
+	atomic.AddUint32(&t.seqNo, 1)
 
 	_, err := t.conn.Write(packet)
 	return err
@@ -62,7 +63,9 @@ func (t *TCPFull) Recv() ([]byte, error) {
 		return nil, ErrPayloadTooLarge
 	}
 
-	restLen := int(packetLen) - 4
+	// packetLen-4 is guaranteed <= MaxPayloadLen (16 MiB), which fits in int
+	// on all supported platforms.
+	restLen := int(packetLen - 4)
 	if cap(t.readBuf) < restLen {
 		t.readBuf = make([]byte, restLen)
 	}

--- a/internal/transport/tcp_obfuscated.go
+++ b/internal/transport/tcp_obfuscated.go
@@ -118,8 +118,15 @@ func (t *TCPObfuscated) Connect() error {
 	copy(decKey[:], reversed[0:32])
 	copy(decIV[:], reversed[32:48])
 
-	t.enc = crypto.NewCTRCipher(encKey[:], encIV[:])
-	t.dec = crypto.NewCTRCipher(decKey[:], decIV[:])
+	var err error
+	t.enc, err = crypto.NewCTRCipher(encKey[:], encIV[:])
+	if err != nil {
+		return fmt.Errorf("tcp_obfuscated: create enc cipher: %w", err)
+	}
+	t.dec, err = crypto.NewCTRCipher(decKey[:], decIV[:])
+	if err != nil {
+		return fmt.Errorf("tcp_obfuscated: create dec cipher: %w", err)
+	}
 
 	encrypted := t.enc.Process(nonce)
 	copy(nonce[56:64], encrypted[56:64])
@@ -150,8 +157,15 @@ func (t *TCPObfuscated) connectReverse() error {
 	copy(decKey[:], nonce[8:40])
 	copy(decIV[:], nonce[40:56])
 
-	t.enc = crypto.NewCTRCipher(encKey[:], encIV[:])
-	t.dec = crypto.NewCTRCipher(decKey[:], decIV[:])
+	var err error
+	t.enc, err = crypto.NewCTRCipher(encKey[:], encIV[:])
+	if err != nil {
+		return fmt.Errorf("tcp_obfuscated: create enc cipher: %w", err)
+	}
+	t.dec, err = crypto.NewCTRCipher(decKey[:], decIV[:])
+	if err != nil {
+		return fmt.Errorf("tcp_obfuscated: create dec cipher: %w", err)
+	}
 
 	t.dec.Process(make([]byte, 64))
 

--- a/internal/transport/ws.go
+++ b/internal/transport/ws.go
@@ -119,6 +119,7 @@ func dialWebsocketTCP(ctx context.Context, addr string) (net.Conn, error) {
 		}
 		conn, err := tls.DialWithDialer(dialer, "tcp", addrHost, &tls.Config{
 			ServerName: host,
+			MinVersion: tls.VersionTLS12,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("ws: tls dial: %w", err)
@@ -196,8 +197,14 @@ func dialObfuscated2(conn net.Conn, marker byte) (*obfsConn, error) {
 	copy(decKey, reversed[0:32])
 	copy(decIV, reversed[32:48])
 
-	enc := crypto.NewCTRCipher(encKey, encIV)
-	dec := crypto.NewCTRCipher(decKey, decIV)
+	enc, err := crypto.NewCTRCipher(encKey, encIV)
+	if err != nil {
+		return nil, fmt.Errorf("obfuscated2: create enc cipher: %w", err)
+	}
+	dec, err := crypto.NewCTRCipher(decKey, decIV)
+	if err != nil {
+		return nil, fmt.Errorf("obfuscated2: create dec cipher: %w", err)
+	}
 
 	encrypted := enc.Process(nonce)
 	copy(nonce[56:64], encrypted[56:64])
@@ -247,8 +254,14 @@ func acceptObfuscated2(conn net.Conn) (*obfsConn, error) {
 	copy(decKey, nonce[8:40])
 	copy(decIV, nonce[40:56])
 
-	enc := crypto.NewCTRCipher(encKey, encIV)
-	dec := crypto.NewCTRCipher(decKey, decIV)
+	enc, err := crypto.NewCTRCipher(encKey, encIV)
+	if err != nil {
+		return nil, fmt.Errorf("obfuscated2: create enc cipher: %w", err)
+	}
+	dec, err := crypto.NewCTRCipher(decKey, decIV)
+	if err != nil {
+		return nil, fmt.Errorf("obfuscated2: create dec cipher: %w", err)
+	}
 
 	dec.Process(make([]byte, 64))
 

--- a/mtproxy/faketls.go
+++ b/mtproxy/faketls.go
@@ -207,10 +207,19 @@ func fakeTLSHandshake(conn net.Conn, secret []byte, domain string) (*tlsConn, er
 	rand.Read(decKey)
 	rand.Read(decIV)
 
+	enc, err := crypto.NewCTRCipher(encKey, encIV)
+	if err != nil {
+		return nil, fmt.Errorf("mtproxy: create enc cipher: %w", err)
+	}
+	dec, err := crypto.NewCTRCipher(decKey, decIV)
+	if err != nil {
+		return nil, fmt.Errorf("mtproxy: create dec cipher: %w", err)
+	}
+
 	return &tlsConn{
 		conn:       conn,
-		enc:        crypto.NewCTRCipher(encKey, encIV),
-		dec:        crypto.NewCTRCipher(decKey, decIV),
+		enc:        enc,
+		dec:        dec,
 		firstWrite: true,
 	}, nil
 }

--- a/mtproxy/obfuscated2.go
+++ b/mtproxy/obfuscated2.go
@@ -59,8 +59,14 @@ func obfuscated2Handshake(conn net.Conn, secret []byte, dcID int, codec byte) (*
 	decIV := make([]byte, 16)
 	copy(decIV, reversed[32:48])
 
-	enc := crypto.NewCTRCipher(encKey, encIV)
-	dec := crypto.NewCTRCipher(decKey, decIV)
+	enc, err := crypto.NewCTRCipher(encKey, encIV)
+	if err != nil {
+		return nil, fmt.Errorf("mtproxy: create enc cipher: %w", err)
+	}
+	dec, err := crypto.NewCTRCipher(decKey, decIV)
+	if err != nil {
+		return nil, fmt.Errorf("mtproxy: create dec cipher: %w", err)
+	}
 
 	header[56] = codec
 	header[57] = codec

--- a/telegram/download_cdn_test.go
+++ b/telegram/download_cdn_test.go
@@ -20,7 +20,10 @@ func TestCDNDecryptChunk(t *testing.T) {
 	originalData := make([]byte, 1024)
 	_, _ = rand.Read(originalData)
 
-	encrypted := crypto.CTREncrypt(originalData, key, iv[:16])
+	encrypted, err := crypto.CTREncrypt(originalData, key, iv[:16])
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	decrypted := cdnDecryptChunk(encrypted, key, iv, 0)
 	if !bytes.Equal(decrypted, originalData) {
@@ -37,7 +40,10 @@ func TestCDNDecryptChunkWithOffset(t *testing.T) {
 	originalData := make([]byte, downloadChunkSize*2)
 	_, _ = rand.Read(originalData)
 
-	encrypted := crypto.CTREncrypt(originalData, key, iv[:16])
+	encrypted, err := crypto.CTREncrypt(originalData, key, iv[:16])
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	decrypted := cdnDecryptChunk(encrypted[downloadChunkSize:], key, iv, int64(downloadChunkSize))
 	if !bytes.Equal(decrypted, originalData[downloadChunkSize:]) {

--- a/telegram/secret.go
+++ b/telegram/secret.go
@@ -596,7 +596,10 @@ func (c *Client) SendSecretFile(ctx context.Context, chatID int32, reader io.Rea
 
 	keyFP := crypto.FileKeyFingerprint(fileKey, fileIV)
 
-	encryptedFileData := crypto.EncryptFile(fileData, fileKey, fileIV)
+	encryptedFileData, err := crypto.EncryptFile(fileData, fileKey, fileIV)
+		if err != nil {
+			return fmt.Errorf("telegram: encrypt file: %w", err)
+		}
 
 	uploadResult, err := c.UploadFile(ctx, bytes.NewReader(encryptedFileData), fileName, int64(len(encryptedFileData)), nil)
 	if err != nil {

--- a/telegram/test_helpers_test.go
+++ b/telegram/test_helpers_test.go
@@ -104,7 +104,10 @@ func (s *testServer) handleConn(conn net.Conn) {
 			pong := &tg.Pong{MsgID: origMsgID, PingID: pingID}
 			respMsg := &tg.MTProtoMessage{MsgID: respMsgID, SeqNo: respSeqNo, Body: pong}
 
-			encrypted := crypto.Pack(respMsg, salt, sessionID, s.authKey, authKeyID)
+			encrypted, err := crypto.Pack(respMsg, salt, sessionID, s.authKey, authKeyID)
+				if err != nil {
+					continue
+				}
 
 			var resp bytes.Buffer
 			binary.Write(&resp, binary.LittleEndian, uint32(len(encrypted)))
@@ -131,7 +134,10 @@ func unpackSafeNoSessionCheck(data, authKey, authKeyID []byte) (constructorID ui
 	msgKey := data[8:24]
 	encrypted := data[24:]
 	keyArr, ivArr := crypto.KDF(authKey, msgKey, false)
-	decrypted = crypto.IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+	decrypted, err = crypto.IGEDecrypt(encrypted, keyArr[:], ivArr[:])
+		if err != nil {
+			return 0, 0, nil, err
+		}
 	tmpChk := make([]byte, 32+len(decrypted))
 	copy(tmpChk, authKey[96:128])
 	copy(tmpChk[32:], decrypted)


### PR DESCRIPTION
## Summary

Fixes from the [2026-05-22 security audit](https://github.com/mtgo-labs/mtgo/tree/main/report/2026-05-22-security-audit) (35 findings, DREAD-scored). Addresses S-tier and A-tier findings plus selected B-tier items.

## Changes by Package

### `internal/crypto` — A4, B4, B1
- **A4 (High):** `newAESBlock`, `IGEEncrypt`, `IGEDecrypt`, `NewCTRCipher` now return `error` instead of panicking. All callers updated across `crypto/`, `session/`, `transport/`, `mtproxy/`, `telegram/`.
- **B4 (Medium):** `ReleaseAESBuf` zeroes buffer contents before returning to `sync.Pool`, preventing key material leakage between operations.
- **B1 (Medium):** `SecretDecrypt` returns a single `errDecryptionFailed` for all failure paths (msg_key mismatch, padding, length) to prevent padding oracle attacks. `rand.Read` error in `SecretEncrypt` padding now propagated instead of silently discarded.

### `internal/session` — A1, B8, B10
- **A1 (High):** `generateRandomBN` now returns `error` if `crypto/rand.Read` fails instead of silently using uninitialized bytes. All callers (initial DH + retry path) updated.
- **B8 (Medium):** Added subgroup membership check after existing range validation: `gA^((dhPrime-1)/2) mod dhPrime == 1`, preventing small-subgroup confinement attacks.
- **B10 (Medium):** Skip expensive `ProbablyPrime` check when `dhPrime` matches the known `crypto.CurrentDHPrime` constant (fast path for standard prime).

### `internal/transport` — A3, A5, B14
- **A3 (High):** `seqNo` access in `tcp_full.go` now uses `sync/atomic` (`LoadUint32`/`AddUint32`/`StoreUint32`) instead of unsynchronized reads and increments.
- **A5 (High):** Integer truncation in packet length validation — `restLen` now computed with `uint32` arithmetic after bounds check, preventing overflow on 32-bit platforms.
- **B14 (Low):** Added `MinVersion: tls.VersionTLS12` to WebSocket TLS config.

### `internal/storage` — B3
- **B3 (Medium):** `adapterWrapper` now has `sync.Mutex` protecting `load`/`save` and all 30 getter/setter methods, preventing data races in concurrent session access.

## Verification

```
go build ./...          # clean
go vet ./...            # clean
go test ./internal/...  # all pass (crypto 39 tests, session 20s, transport)
go test -race ./internal/...  # no races detected
```

## Audit Finding Coverage

| ID | Severity | Finding | Status |
|----|----------|---------|--------|
| S1 | Critical | Container OOM (gzip amplification) | Out of scope (container config) |
| S2 | Critical | Timing oracle in msg_key | Already fixed in main |
| A1 | High | rand.Read error ignored | **Fixed** (this PR) |
| A3 | High | seqNo data race | **Fixed** (this PR) |
| A4 | High | Panic in AES-IGE | **Fixed** (this PR) |
| A5 | High | Integer truncation (32-bit) | **Fixed** (this PR) |
| B1 | Medium | Padding oracle (distinct errors) | **Fixed** (this PR) |
| B3 | Medium | adapterWrapper race | **Fixed** (this PR) |
| B4 | Medium | Pool buffer zeroing | **Fixed** (this PR) |
| B8 | Medium | DH subgroup check | **Fixed** (this PR) |
| B10 | Medium | Known prime fast path | **Fixed** (this PR) |
| B14 | Low | TLS MinVersion | **Fixed** (this PR) |