### PR TITLE
fix(telegram): propagate context through upload and DC migration paths

### DIFF
--- a/telegram/client.go
+++ b/telegram/client.go
@@ -1427,7 +1427,7 @@ func (c *Client) Health() HealthStatus {
 	return c.state.Health()
 }
 
-func (c *Client) handleMigrationError(rpcErr *tgerr.Error, query tg.TLObject) (tg.TLObject, error) {
+func (c *Client) handleMigrationError(ctx context.Context, rpcErr *tgerr.Error, query tg.TLObject) (tg.TLObject, error) {
 	targetDC := rpcErr.Argument
 	if targetDC <= 0 {
 		return nil, &MigrationError{TargetDC: targetDC, Err: ErrMigrationUnknown}
@@ -1448,9 +1448,9 @@ func (c *Client) handleMigrationError(rpcErr *tgerr.Error, query tg.TLObject) (t
 
 	switch rpcErr.Type {
 	case "PHONE_MIGRATE", "NETWORK_MIGRATE", "USER_MIGRATE":
-		return c.migrateAndRetry(targetDC, query, st)
+		return c.migrateAndRetry(ctx, targetDC, query, st)
 	case "FILE_MIGRATE", "STATS_MIGRATE":
-		return c.migrateExportImport(targetDC, query, st)
+		return c.migrateExportImport(ctx, targetDC, query, st)
 	default:
 		return nil, &MigrationError{TargetDC: targetDC, Err: fmt.Errorf("unsupported migration type: %s", rpcErr.Type)}
 	}
@@ -1471,7 +1471,7 @@ func isIdempotent(query tg.TLObject) bool {
 	return idempotentConstructors[query.ConstructorID()]
 }
 
-func (c *Client) migrateAndRetry(targetDC int, query tg.TLObject, st storage.Storage) (tg.TLObject, error) {
+func (c *Client) migrateAndRetry(ctx context.Context, targetDC int, query tg.TLObject, st storage.Storage) (tg.TLObject, error) {
 	if !isIdempotent(query) {
 		return nil, &UnsafeMigrationError{TargetDC: targetDC, Method: fmt.Sprintf("%T", query)}
 	}
@@ -1501,7 +1501,7 @@ func (c *Client) migrateAndRetry(targetDC int, query tg.TLObject, st storage.Sto
 	if retries < 1 {
 		retries = 1
 	}
-	result, err := c.Invoke(context.Background(), retryQuery, retries, 30*time.Second)
+	result, err := c.Invoke(ctx, retryQuery, retries, 30*time.Second)
 	if err != nil {
 		return nil, &MigrationError{TargetDC: targetDC, Err: err}
 	}
@@ -1512,9 +1512,7 @@ func (c *Client) migrateAndRetry(targetDC int, query tg.TLObject, st storage.Sto
 	return result, nil
 }
 
-func (c *Client) migrateExportImport(targetDC int, query tg.TLObject, _ storage.Storage) (tg.TLObject, error) {
-	ctx := context.Background()
-
+func (c *Client) migrateExportImport(ctx context.Context, targetDC int, query tg.TLObject, _ storage.Storage) (tg.TLObject, error) {
 	rpc, err := c.dcRPC(ctx, targetDC)
 	if err != nil {
 		return nil, &MigrationError{TargetDC: targetDC, Err: err}
@@ -1548,7 +1546,7 @@ func (c *Client) Invoke(ctx context.Context, query tg.TLObject, retries int, tim
 	if err != nil {
 		var rpcErr *tgerr.Error
 		if errors.As(err, &rpcErr) && rpcErr.Code == 303 {
-			return c.handleMigrationError(rpcErr, query)
+			return c.handleMigrationError(ctx, rpcErr, query)
 		}
 		return nil, fmt.Errorf("client: invoke: %w", err)
 	}

--- a/telegram/input_file.go
+++ b/telegram/input_file.go
@@ -97,7 +97,7 @@ const (
 	mediaKindSticker   = types.MediaKindSticker
 )
 
-func resolveFile(f *InputFile, c *Client, kind mediaKind) (tg.InputMediaClass, error) {
+func resolveFile(ctx context.Context, f *InputFile, c *Client, kind mediaKind) (tg.InputMediaClass, error) {
 	if f.GetFileID() != "" {
 		return resolveFromFileID(f, kind)
 	}
@@ -113,7 +113,7 @@ func resolveFile(f *InputFile, c *Client, kind mediaKind) (tg.InputMediaClass, e
 		}
 	}
 	if f.GetReader() != nil {
-		return resolveUpload(f, c, kind)
+		return resolveUpload(ctx, f, c, kind)
 	}
 	return nil, ErrInputFileEmpty
 }
@@ -177,12 +177,12 @@ func openFile(f *InputFile) error {
 	return nil
 }
 
-func resolveUpload(f *InputFile, c *Client, kind mediaKind) (tg.InputMediaClass, error) {
+func resolveUpload(ctx context.Context, f *InputFile, c *Client, kind mediaKind) (tg.InputMediaClass, error) {
 	if kind == mediaKindAuto {
 		kind = guessKind(f.GetFileName())
 	}
 
-	result, err := c.UploadFile(context.Background(), f.GetReader(), f.GetFileName(), f.GetFileSize(), nil)
+	result, err := c.UploadFile(ctx, f.GetReader(), f.GetFileName(), f.GetFileSize(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("input_file: upload: %w", err)
 	}

--- a/telegram/plugin.go
+++ b/telegram/plugin.go
@@ -202,7 +202,7 @@ func (c *Client) dispatchUpdate(d *HandlerDispatcher, update *Update) {
 	inner := &dispatchAllHandler{d: d, c: c, update: update}
 	wrapped := c.applyMiddleware(Handler(inner))
 
-	cctx := c.NewContext(context.TODO())
+	cctx := c.NewContext(context.Background())
 	cctx.Update = update
 	populateContext(cctx, update)
 	wrapped.Handle(cctx)

--- a/telegram/reconnect_health_test.go
+++ b/telegram/reconnect_health_test.go
@@ -256,13 +256,13 @@ func TestMigrationErrorParsing(t *testing.T) {
 	client.storage = NewMemoryStorage()
 
 	rpcErr := &tgerr.Error{Code: 303, Type: "PHONE_MIGRATE", Argument: 4}
-	_, err := client.handleMigrationError(rpcErr, nil)
+	_, err := client.handleMigrationError(context.Background(), rpcErr, nil)
 	if err == nil {
 		t.Fatal("should return error for nil query with non-idempotent migration path")
 	}
 
 	rpcErrBad := &tgerr.Error{Code: 303, Type: "PHONE_MIGRATE", Argument: 0}
-	_, err = client.handleMigrationError(rpcErrBad, nil)
+	_, err = client.handleMigrationError(context.Background(), rpcErrBad, nil)
 	if err == nil {
 		t.Fatal("should return error for DC 0")
 	}
@@ -282,7 +282,7 @@ func TestMigrationErrorNon303(t *testing.T) {
 	client.storage = NewMemoryStorage()
 
 	rpcErr := &tgerr.Error{Code: 400, Type: "BAD_REQUEST", Argument: 5}
-	_, err := client.handleMigrationError(rpcErr, nil)
+	_, err := client.handleMigrationError(context.Background(), rpcErr, nil)
 	if err != rpcErr {
 		t.Fatalf("non-303 with valid argument: got %v, want original error", err)
 	}
@@ -295,7 +295,7 @@ func TestMigrationUnknownType(t *testing.T) {
 	client.storage = NewMemoryStorage()
 
 	rpcErr := &tgerr.Error{Code: 303, Type: "GARBAGE_MIGRATE", Argument: 5}
-	_, err := client.handleMigrationError(rpcErr, nil)
+	_, err := client.handleMigrationError(context.Background(), rpcErr, nil)
 	var migErr *MigrationError
 	if !errors.As(err, &migErr) {
 		t.Fatalf("got %T, want *MigrationError", err)
@@ -313,7 +313,7 @@ func TestMigrationUnsafeNonIdempotent(t *testing.T) {
 
 	query := &tg.MessagesSendMessageRequest{}
 	rpcErr := &tgerr.Error{Code: 303, Type: "PHONE_MIGRATE", Argument: 4}
-	_, err := client.handleMigrationError(rpcErr, query)
+	_, err := client.handleMigrationError(context.Background(), rpcErr, query)
 	var unsafeErr *UnsafeMigrationError
 	if !errors.As(err, &unsafeErr) {
 		t.Fatalf("got %T, want *UnsafeMigrationError", err)
@@ -531,13 +531,13 @@ func TestInvokeMigrationOn303Error(t *testing.T) {
 	client.storage = NewMemoryStorage()
 
 	migrating := &tgerr.Error{Code: 303, Type: "PHONE_MIGRATE", Argument: 4}
-	_, err := client.handleMigrationError(migrating, &tg.MessagesSendMessageRequest{})
+	_, err := client.handleMigrationError(context.Background(), migrating, &tg.MessagesSendMessageRequest{})
 	var unsafeErr *UnsafeMigrationError
 	if !errors.As(err, &unsafeErr) {
 		t.Fatalf("got %T, want *UnsafeMigrationError", err)
 	}
 
-	result, err := client.handleMigrationError(migrating, &tg.AuthExportAuthorizationRequest{})
+	result, err := client.handleMigrationError(context.Background(), migrating, &tg.AuthExportAuthorizationRequest{})
 	_ = result
 	_ = err
 }

--- a/telegram/rpc.go
+++ b/telegram/rpc.go
@@ -58,7 +58,7 @@ func (ci *clientInvoker) RPCInvoke(ctx context.Context, input tg.TLObject, decod
 			if shouldReturnMigrationToCaller(input, parsed) {
 				return nil, parsed
 			}
-			return ci.client.handleMigrationError(parsed, input)
+			return ci.client.handleMigrationError(ctx, parsed, input)
 		}
 		return nil, parsed
 	}
@@ -91,7 +91,7 @@ func (ci *clientInvoker) RPCInvokeRaw(ctx context.Context, input tg.TLObject) ([
 			if shouldReturnMigrationToCaller(input, rpcErr) {
 				return nil, rpcErr
 			}
-			_, migErr := ci.client.handleMigrationError(rpcErr, input)
+			_, migErr := ci.client.handleMigrationError(ctx, rpcErr, input)
 			return nil, migErr
 		}
 		return nil, err

--- a/telegram/upload.go
+++ b/telegram/upload.go
@@ -531,7 +531,7 @@ func (c *Client) SendPhoto(ctx context.Context, chatID int64, file *InputFile, c
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindPhoto)
+	media, err := resolveFile(ctx, file, c, mediaKindPhoto)
 	if err != nil {
 		return nil, fmt.Errorf("send_photo: %w", err)
 	}
@@ -546,7 +546,7 @@ func (c *Client) SendDocument(ctx context.Context, chatID int64, file *InputFile
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindDocument)
+	media, err := resolveFile(ctx, file, c, mediaKindDocument)
 	if err != nil {
 		return nil, fmt.Errorf("send_document: %w", err)
 	}
@@ -569,7 +569,7 @@ func (c *Client) SendVideo(ctx context.Context, chatID int64, file *InputFile, c
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindVideo)
+	media, err := resolveFile(ctx, file, c, mediaKindVideo)
 	if err != nil {
 		return nil, fmt.Errorf("send_video: %w", err)
 	}
@@ -589,7 +589,7 @@ func (c *Client) SendAudio(ctx context.Context, chatID int64, file *InputFile, c
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindAudio)
+	media, err := resolveFile(ctx, file, c, mediaKindAudio)
 	if err != nil {
 		return nil, fmt.Errorf("send_audio: %w", err)
 	}
@@ -608,7 +608,7 @@ func (c *Client) SendAnimation(ctx context.Context, chatID int64, file *InputFil
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindAnimation)
+	media, err := resolveFile(ctx, file, c, mediaKindAnimation)
 	if err != nil {
 		return nil, fmt.Errorf("send_animation: %w", err)
 	}
@@ -623,7 +623,7 @@ func (c *Client) SendVoice(ctx context.Context, chatID int64, file *InputFile, c
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindVoice)
+	media, err := resolveFile(ctx, file, c, mediaKindVoice)
 	if err != nil {
 		return nil, fmt.Errorf("send_voice: %w", err)
 	}
@@ -638,7 +638,7 @@ func (c *Client) SendVideoNote(ctx context.Context, chatID int64, file *InputFil
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindVideoNote)
+	media, err := resolveFile(ctx, file, c, mediaKindVideoNote)
 	if err != nil {
 		return nil, fmt.Errorf("send_video_note: %w", err)
 	}
@@ -653,7 +653,7 @@ func (c *Client) SendSticker(ctx context.Context, chatID int64, file *InputFile,
 	if opt.FileName != "" && file.GetFileName() == "" {
 		file.SetFileName(opt.FileName)
 	}
-	media, err := resolveFile(file, c, mediaKindSticker)
+	media, err := resolveFile(ctx, file, c, mediaKindSticker)
 	if err != nil {
 		return nil, fmt.Errorf("send_sticker: %w", err)
 	}


### PR DESCRIPTION
- resolveFile/resolveUpload now accept ctx and propagate it to UploadFile instead of using context.Background()
- SendPhoto/SendDocument/SendVideo/SendAudio/SendAnimation/SendVoice/ SendVideoNote/SendSticker now pass their ctx through to resolveFile
- handleMigrationError, migrateAndRetry, migrateExportImport now accept and propagate ctx instead of creating context.Background()
- rpc.go clientInvoker passes ctx to handleMigrationError
- plugin.go: replaced context.TODO() with context.Background()