### PR TITLE
fix(telegram): parse edited message updates from edit RPCs

### DIFF
--- a/telegram/messages.go
+++ b/telegram/messages.go
@@ -619,6 +619,18 @@ func extractSingleMessage(result tg.UpdatesClass, binder types.Binder) (*types.M
 					m.SetBinder(binder)
 				}
 				return m, nil
+			case *tg.UpdateEditMessage:
+				m := types.ParseMessage(upd.Message, pm)
+				if m != nil {
+					m.SetBinder(binder)
+				}
+				return m, nil
+			case *tg.UpdateEditChannelMessage:
+				m := types.ParseMessage(upd.Message, pm)
+				if m != nil {
+					m.SetBinder(binder)
+				}
+				return m, nil
 			}
 		}
 		return nil, ErrNoMessageUpdates
@@ -629,6 +641,13 @@ func extractSingleMessage(result tg.UpdatesClass, binder types.Binder) (*types.M
 			Channels: make(map[int64]*tg.Channel),
 		}
 		if upd, ok := v.Update.(*tg.UpdateNewMessage); ok {
+			m := types.ParseMessage(upd.Message, pm)
+			if m != nil {
+				m.SetBinder(binder)
+			}
+			return m, nil
+		}
+		if upd, ok := v.Update.(*tg.UpdateEditMessage); ok {
 			m := types.ParseMessage(upd.Message, pm)
 			if m != nil {
 				m.SetBinder(binder)

--- a/telegram/messages_test.go
+++ b/telegram/messages_test.go
@@ -133,6 +133,58 @@ func TestEditMessageCaption(t *testing.T) {
 	}
 }
 
+func TestEditMessageTextParsesEditMessageUpdate(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerUser{UserID: 10, AccessHash: 20})
+	inv.setResult(tg.MessagesEditMessageTypeID, &tg.Updates{
+		Updates: []tg.UpdateClass{
+			&tg.UpdateEditMessage{
+				Message: &tg.Message{
+					ID:      55,
+					PeerID:  &tg.PeerUser{UserID: 10},
+					Message: "edited text",
+				},
+			},
+		},
+		Users: []tg.UserClass{},
+		Chats: []tg.ChatClass{},
+	})
+
+	msg, err := c.EditMessageText(context.Background(), 10, 55, "edited text")
+	if err != nil {
+		t.Fatalf("EditMessageText() error: %v", err)
+	}
+	if msg == nil || msg.ID != 55 || msg.Text != "edited text" {
+		t.Fatalf("EditMessageText() = %#v, want edited message 55", msg)
+	}
+}
+
+func TestEditMessageCaptionParsesEditChannelMessageUpdate(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+	inv.setResult(tg.MessagesEditMessageTypeID, &tg.Updates{
+		Updates: []tg.UpdateClass{
+			&tg.UpdateEditChannelMessage{
+				Message: &tg.Message{
+					ID:      55,
+					PeerID:  &tg.PeerChannel{ChannelID: 10},
+					Message: "edited caption",
+				},
+			},
+		},
+		Users: []tg.UserClass{},
+		Chats: []tg.ChatClass{},
+	})
+
+	msg, err := c.EditMessageCaption(context.Background(), 10, 55, "edited caption")
+	if err != nil {
+		t.Fatalf("EditMessageCaption() error: %v", err)
+	}
+	if msg == nil || msg.ID != 55 || msg.Text != "edited caption" {
+		t.Fatalf("EditMessageCaption() = %#v, want edited channel message 55", msg)
+	}
+}
+
 func TestGetMessagesUsesChannelsGetMessagesForChannels(t *testing.T) {
 	c, inv := newClientWithMock(t)
 	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})


### PR DESCRIPTION
## Summary

- parse `UpdateEditMessage` and `UpdateEditChannelMessage` in `extractSingleMessage`
- handle edit RPC responses from `EditMessageText` and `EditMessageCaption` without returning `ErrNoMessageUpdates`
- add regression tests for edited message and edited channel message responses

## Why

Telegram can return edit updates after a successful `messages.editMessage` call. Previously `extractSingleMessage` only accepted new-message updates, so successful edit calls could still return:

```text
no message found in UpdatesTL