### PR TITLE
fix(tlgen): preserve bare vector encoding

### DIFF
--- a/compiler/tlgen/generator_test.go
+++ b/compiler/tlgen/generator_test.go
@@ -24,11 +24,12 @@ func TestGoType(t *testing.T) {
 		{"Vector<int>", "[]int32"},
 		{"Vector<long>", "[]int64"},
 		{"Vector<string>", "[]string"},
+		{"vector<future_salt>", "[]*FutureSalt"},
 		{"Type", "TLObject"},
 	}
 
 	for _, tt := range tests {
-		got := goType(tt.tlType, "types", nil, nil)
+		got := goType(tt.tlType, "types", nil, map[string][]Combinator{"FutureSalt": {{QualName: "future_salt"}}})
 		if got != tt.want {
 			t.Errorf("goType(%q) = %q, want %q", tt.tlType, got, tt.want)
 		}
@@ -134,6 +135,74 @@ func TestWriteExpr(t *testing.T) {
 		got := writeExpr(tt.arg, tt.goType, "v")
 		if got != tt.want {
 			t.Errorf("writeExpr(%+v, %q) = %q, want %q", tt.arg, tt.goType, got, tt.want)
+		}
+	}
+}
+
+func TestWriteExprBareVectorConstructor(t *testing.T) {
+	arg := Arg{Name: "salts", Type: "vector<future_salt>"}
+	typeToConstructor := map[string][]Combinator{
+		"FutureSalt": {{
+			QualName: "future_salt",
+			Type:     "FutureSalt",
+			Args: []Arg{
+				{Name: "valid_since", Type: "int", FlagBit: -1},
+				{Name: "valid_until", Type: "int", FlagBit: -1},
+				{Name: "salt", Type: "long", FlagBit: -1},
+			},
+		}},
+	}
+
+	got := writeExpr(arg, "[]*FutureSalt", "v", typeToConstructor)
+	if strings.Contains(got, "0x1cb5c415") {
+		t.Fatalf("bare vector write should not include vector constructor: %s", got)
+	}
+	if strings.Contains(got, "EncodeTLObject") {
+		t.Fatalf("bare vector element write should not use boxed object encoding: %s", got)
+	}
+	for _, want := range []string{"WriteInt(b, uint32(len(v.Salts)))", "_item.ValidSince", "_item.ValidUntil", "_item.Salt"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("writeExpr missing %q in %s", want, got)
+		}
+	}
+}
+
+func TestBareVectorBoxedElements(t *testing.T) {
+	arg := Arg{Name: "ips", Type: "vector<IpPort>"}
+
+	write := writeExpr(arg, "[]IpPortClass", "v", nil)
+	if strings.Contains(write, "0x1cb5c415") {
+		t.Fatalf("bare vector write should not include vector constructor: %s", write)
+	}
+	if !strings.Contains(write, "EncodeTLObject") {
+		t.Fatalf("boxed vector elements should use TL object encoding: %s", write)
+	}
+
+	read := buildReadExpr(arg, "[]IpPortClass", nil, nil)
+	if strings.Contains(read, "_vhdr") {
+		t.Fatalf("bare vector read should not include vector header: %s", read)
+	}
+	if !strings.Contains(read, "ReadTLObject(r)") || !strings.Contains(read, ".(IpPortClass)") {
+		t.Fatalf("boxed vector elements should use TL object decoding: %s", read)
+	}
+	if strings.Index(read, "if _errIps != nil") > strings.Index(read, "_objIps.(IpPortClass)") {
+		t.Fatalf("read error should be checked before type assertion: %s", read)
+	}
+}
+
+func TestBuildReadExprBareVectorConstructor(t *testing.T) {
+	arg := Arg{Name: "salts", Type: "vector<future_salt>"}
+	typeToConstructor := map[string][]Combinator{
+		"FutureSalt": {{QualName: "future_salt", Type: "FutureSalt"}},
+	}
+
+	got := buildReadExpr(arg, "[]*FutureSalt", nil, typeToConstructor)
+	if strings.Contains(got, "_vhdr") || strings.Contains(got, "ReadTLObject") {
+		t.Fatalf("bare vector read should not use boxed vector/object decoding: %s", got)
+	}
+	for _, want := range []string{"_cntSalts", "checkVectorCount", "DecodeFutureSalt(r)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("buildReadExpr missing %q in %s", want, got)
 		}
 	}
 }

--- a/compiler/tlgen/helpers.go
+++ b/compiler/tlgen/helpers.go
@@ -478,7 +478,7 @@ func buildTypeData(c Combinator, section string, baseTypes map[string]bool, type
 
 		fields = append(fields, fd)
 
-		wl := buildWriteLine(arg, fd, section, baseTypes)
+		wl := buildWriteLine(arg, fd, section, baseTypes, typeToConstructor)
 		writeLines = append(writeLines, wl)
 
 		rl := buildReadLine(arg, fd, section, baseTypes, typeToConstructor)
@@ -527,7 +527,96 @@ func isDirectOptionalScalar(goType string) bool {
 	return false
 }
 
-func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]bool) writeLine {
+func bareVectorInner(tlType string) (string, bool) {
+	if strings.HasPrefix(tlType, "vector<") && strings.HasSuffix(tlType, ">") {
+		return strings.TrimSuffix(strings.TrimPrefix(tlType, "vector<"), ">"), true
+	}
+	return "", false
+}
+
+func constructorByQualName(name string, typeToConstructor map[string][]Combinator) (Combinator, bool) {
+	if typeToConstructor == nil {
+		return Combinator{}, false
+	}
+	stripped := stripNamespace(name)
+	for _, constructors := range typeToConstructor {
+		for _, c := range constructors {
+			if c.QualName == name || c.QualName == stripped || stripNamespace(c.QualName) == stripped {
+				return c, true
+			}
+		}
+	}
+	return Combinator{}, false
+}
+
+func writeBareVectorExpr(inner, access string, typeToConstructor map[string][]Combinator) string {
+	switch stripNamespace(inner) {
+	case "int":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteInt(b, uint32(_item)) }", access, access)
+	case "long":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteLong(b, _item) }", access, access)
+	case "string":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteString(b, _item) }", access, access)
+	case "bytes":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteBytes(b, _item) }", access, access)
+	}
+
+	if c, ok := constructorByQualName(inner, typeToConstructor); ok {
+		var body strings.Builder
+		for _, a := range c.Args {
+			if a.Type == "#" && a.Name == "flags" {
+				body.WriteString("WriteInt(b, uint32(_item.Flags))\n")
+				continue
+			}
+			gt := resolveGoTypeForField(a, "types", nil, typeToConstructor)
+			body.WriteString(writeExpr(a, gt, "_item", typeToConstructor))
+			body.WriteByte('\n')
+		}
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s {\n%s}", access, access, indentCode(strings.TrimRight(body.String(), "\n"), "\t"))
+	}
+
+	return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { EncodeTLObject(b, _item) }", access, access)
+}
+
+func readBareVectorExpr(inner, assign, fname, goType string, typeToConstructor map[string][]Combinator) string {
+	idx := fname
+	elemType := strings.TrimPrefix(goType, "[]")
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "_cnt%s, _ecnt%s := r.ReadUint32()\n", idx, idx)
+	fmt.Fprintf(&buf, "if _ecnt%s != nil { return nil, _ecnt%s }\n", idx, idx)
+	fmt.Fprintf(&buf, "if _err%s := checkVectorCount(_cnt%s); _err%s != nil {\n\treturn nil, _err%s\n}\n", idx, idx, idx, idx)
+	fmt.Fprintf(&buf, "%s = make(%s, _cnt%s)\n", assign, goType, idx)
+	fmt.Fprintf(&buf, "for _i%s := range %s {\n", idx, assign)
+
+	switch stripNamespace(inner) {
+	case "int":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadInt32()\n", idx, idx)
+	case "long":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadInt64()\n", idx, idx)
+	case "string":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadString()\n", idx, idx)
+	case "bytes":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadBytes()\n", idx, idx)
+	default:
+		if c, ok := constructorByQualName(inner, typeToConstructor); ok {
+			fmt.Fprintf(&buf, "\t_item%s, _err%s := Decode%s(r)\n", idx, idx, SnakeToPascal(c.QualName))
+		} else {
+			fmt.Fprintf(&buf, "\t_obj%s, _err%s := ReadTLObject(r)\n", idx, idx)
+			fmt.Fprintf(&buf, "\tif _err%s != nil {\n\t\treturn nil, _err%s\n\t}\n", idx, idx)
+			fmt.Fprintf(&buf, "\t_item%s := %s\n", idx, typeAssertExpr("_obj"+idx, elemType))
+			fmt.Fprintf(&buf, "\t%s[_i%s] = _item%s\n", assign, idx, idx)
+			buf.WriteString("}")
+			return buf.String()
+		}
+	}
+
+	fmt.Fprintf(&buf, "\tif _err%s != nil {\n\t\treturn nil, _err%s\n\t}\n", idx, idx)
+	fmt.Fprintf(&buf, "\t%s[_i%s] = _item%s\n", assign, idx, idx)
+	buf.WriteString("}")
+	return buf.String()
+}
+
+func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]bool, typeToConstructor map[string][]Combinator) writeLine {
 	wl := writeLine{
 		FlagName: fd.FlagName,
 		FlagBit:  arg.FlagBit,
@@ -537,12 +626,12 @@ func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]
 		wl.IsGuarded = true
 	}
 
-	wl.Code = writeExpr(arg, fd.GoType, "v")
+	wl.Code = writeExpr(arg, fd.GoType, "v", typeToConstructor)
 
 	return wl
 }
 
-func writeExpr(arg Arg, goType string, receiver string) string {
+func writeExpr(arg Arg, goType string, receiver string, typeMaps ...map[string][]Combinator) string {
 	fieldName := fieldNameFromTL(arg.Name)
 	access := fmt.Sprintf("%s.%s", receiver, fieldName)
 
@@ -550,6 +639,14 @@ func writeExpr(arg Arg, goType string, receiver string) string {
 	deref := access
 	if isPtr {
 		deref = "*" + access
+	}
+
+	var typeToConstructor map[string][]Combinator
+	if len(typeMaps) > 0 {
+		typeToConstructor = typeMaps[0]
+	}
+	if inner, ok := bareVectorInner(arg.Type); ok {
+		return writeBareVectorExpr(inner, access, typeToConstructor)
 	}
 
 	argType := normalizeVectorType(arg.Type)
@@ -619,6 +716,10 @@ func buildReadLine(arg Arg, fd fieldData, section string, baseTypes map[string]b
 func buildReadExpr(arg Arg, goType string, baseTypes map[string]bool, typeToConstructor map[string][]Combinator) string {
 	assign := fmt.Sprintf("v.%s", fieldNameFromTL(arg.Name))
 	fname := fieldNameFromTL(arg.Name)
+	if inner, ok := bareVectorInner(arg.Type); ok {
+		return readBareVectorExpr(inner, assign, fname, goType, typeToConstructor)
+	}
+
 	argType := normalizeVectorType(arg.Type)
 	argType = stripNamespace(argType)
 

--- a/tg/core_types_gen.go
+++ b/tg/core_types_gen.go
@@ -12660,10 +12660,11 @@ func (v *FutureSalts) Encode(b *bytes.Buffer) error {
 	WriteInt(b, FutureSaltsTypeID)
 	WriteLong(b, v.ReqMsgID)
 	WriteInt(b, uint32(v.Now))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Salts)))
 	for _, _item := range v.Salts {
-		EncodeTLObject(b, _item)
+		WriteInt(b, uint32(_item.ValidSince))
+		WriteInt(b, uint32(_item.ValidUntil))
+		WriteLong(b, _item.Salt)
 	}
 	return nil
 }
@@ -12681,10 +12682,6 @@ func DecodeFutureSalts(r *Reader) (*FutureSalts, error) {
 		return nil, _eNow
 	}
 	v.Now = _rNow
-	_vhdrSalts, _ehdrSalts := r.ReadUint32()
-	if _ehdrSalts != nil {
-		return nil, _ehdrSalts
-	}
 	_cntSalts, _ecntSalts := r.ReadUint32()
 	if _ecntSalts != nil {
 		return nil, _ecntSalts
@@ -12694,13 +12691,12 @@ func DecodeFutureSalts(r *Reader) (*FutureSalts, error) {
 	}
 	v.Salts = make([]*FutureSalt, _cntSalts)
 	for _iSalts := range v.Salts {
-		_objSalts, _errSalts := ReadTLObject(r)
+		_itemSalts, _errSalts := DecodeFutureSalt(r)
 		if _errSalts != nil {
 			return nil, _errSalts
 		}
-		v.Salts[_iSalts] = _objSalts.(*FutureSalt)
+		v.Salts[_iSalts] = _itemSalts
 	}
-	_ = _vhdrSalts
 	return v, nil
 }
 
@@ -13089,7 +13085,6 @@ func (v *AccessPointRule) Encode(b *bytes.Buffer) error {
 	WriteInt(b, AccessPointRuleTypeID)
 	WriteString(b, v.PhonePrefixRules)
 	WriteInt(b, uint32(v.DCID))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Ips)))
 	for _, _item := range v.Ips {
 		EncodeTLObject(b, _item)
@@ -13110,10 +13105,6 @@ func DecodeAccessPointRule(r *Reader) (*AccessPointRule, error) {
 		return nil, _eDCID
 	}
 	v.DCID = _rDCID
-	_vhdrIps, _ehdrIps := r.ReadUint32()
-	if _ehdrIps != nil {
-		return nil, _ehdrIps
-	}
 	_cntIps, _ecntIps := r.ReadUint32()
 	if _ecntIps != nil {
 		return nil, _ecntIps
@@ -13127,9 +13118,9 @@ func DecodeAccessPointRule(r *Reader) (*AccessPointRule, error) {
 		if _errIps != nil {
 			return nil, _errIps
 		}
-		v.Ips[_iIps] = _objIps.(IpPortClass)
+		_itemIps := _objIps.(IpPortClass)
+		v.Ips[_iIps] = _itemIps
 	}
-	_ = _vhdrIps
 	return v, nil
 }
 

--- a/tg/help_types_gen.go
+++ b/tg/help_types_gen.go
@@ -2206,7 +2206,6 @@ func (v *HelpConfigSimple) Encode(b *bytes.Buffer) error {
 	WriteInt(b, HelpConfigSimpleTypeID)
 	WriteInt(b, uint32(v.Date))
 	WriteInt(b, uint32(v.Expires))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Rules)))
 	for _, _item := range v.Rules {
 		EncodeTLObject(b, _item)
@@ -2227,10 +2226,6 @@ func DecodeHelpConfigSimple(r *Reader) (*HelpConfigSimple, error) {
 		return nil, _eExpires
 	}
 	v.Expires = _rExpires
-	_vhdrRules, _ehdrRules := r.ReadUint32()
-	if _ehdrRules != nil {
-		return nil, _ehdrRules
-	}
 	_cntRules, _ecntRules := r.ReadUint32()
 	if _ecntRules != nil {
 		return nil, _ecntRules
@@ -2244,9 +2239,9 @@ func DecodeHelpConfigSimple(r *Reader) (*HelpConfigSimple, error) {
 		if _errRules != nil {
 			return nil, _errRules
 		}
-		v.Rules[_iRules] = _objRules.(*AccessPointRule)
+		_itemRules := _objRules.(*AccessPointRule)
+		v.Rules[_iRules] = _itemRules
 	}
-	_ = _vhdrRules
 	return v, nil
 }
 

--- a/tg/message_test.go
+++ b/tg/message_test.go
@@ -35,11 +35,33 @@ func TestMessage_ConstructorID(t *testing.T) {
 	}
 }
 
+func TestDecodeFutureSaltsBareVector(t *testing.T) {
+	var buf bytes.Buffer
+	WriteLong(&buf, 1)
+	WriteInt(&buf, 2)
+	WriteInt(&buf, 1)
+	WriteInt(&buf, 1780476673)
+	WriteInt(&buf, 1780480273)
+	WriteLong(&buf, 0x1122334455667788)
+
+	r := NewReader(buf.Bytes())
+	defer ReleaseReader(r)
+	got, err := DecodeFutureSalts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Salts) != 1 {
+		t.Fatalf("len(got.Salts) = %d, want 1", len(got.Salts))
+	}
+	if got.Salts[0].ValidSince != 1780476673 || got.Salts[0].ValidUntil != 1780480273 || got.Salts[0].Salt != 0x1122334455667788 {
+		t.Fatalf("unexpected salt: %+v", got.Salts[0])
+	}
+}
+
 func TestDecodeFutureSaltsRejectsHugeVector(t *testing.T) {
 	var buf bytes.Buffer
 	WriteLong(&buf, 1)
 	WriteInt(&buf, 2)
-	WriteInt(&buf, vectorBareID)
 	WriteInt(&buf, maxVectorElements+1)
 
 	r := NewReader(buf.Bytes())


### PR DESCRIPTION

## Summary

Fix `tlgen` so lowercase `vector<...>` keeps TL bare-vector semantics instead of being generated as boxed `Vector<...>`.

## Bug

Telegram's MTProto schema defines `future_salts` as:

```tl
future_salts#ae500895 req_msg_id:long now:int salts:vector<future_salt> = FutureSalts;
```

Lowercase `vector<future_salt>` is a bare vector, and lowercase `future_salt` is a bare constructor type. The serialized response contains:

```text
future_salts#...
req_msg_id
now
count
valid_since valid_until salt
...
```

It does not contain the `0x1cb5c415` vector constructor, and each `future_salt` item does not contain `future_salt#0949d9dc`.

Before this change, `tlgen` normalized lowercase `vector<...>` into uppercase `Vector<...>`, causing generated code to expect boxed vector/object encoding. Real Telegram responses could then fail with errors like:

```text
TL decode failed: constructor_name=future_salts err=tg: vector too large: count=1780476673
```

The `1780476673` value is actually the first `future_salt.valid_since` timestamp, misread as a vector count.

## Minimal Reproduction

Before the fix, this bare `FutureSalts` body fails to decode because the generated decoder expects a vector constructor before the count:

```go
func TestDecodeFutureSaltsBareVector(t *testing.T) {
    var buf bytes.Buffer
    tg.WriteLong(&buf, 1) // req_msg_id
    tg.WriteInt(&buf, 2)  // now

    tg.WriteInt(&buf, 1)          // bare vector count
    tg.WriteInt(&buf, 1780476673) // future_salt.valid_since
    tg.WriteInt(&buf, 1780480273) // future_salt.valid_until
    tg.WriteLong(&buf, 0x1122334455667788)

    r := tg.NewReader(buf.Bytes())
    defer tg.ReleaseReader(r)

    _, err := tg.DecodeFutureSalts(r)
    if err != nil {
        t.Fatal(err)
    }
}
```

## Fix

- Preserve lowercase `vector<...>` as a bare vector during code generation.
- Generate bare count-only vector encoding/decoding for lowercase `vector<...>`.
- Generate bare field encoding/decoding when the inner vector element names a bare constructor, e.g. `future_salt`.
- Keep boxed element handling for uppercase inner types such as `vector<IpPort>`.
- Update generated code for `FutureSalts`, `AccessPointRule`, and `HelpConfigSimple`.

## Tests

```bash
go test ./compiler/tlgen
go test ./tg
go test ./internal/session
go test ./...
```
