### PR TITLE
Fix MTProto media send and edit flag mappings

### DIFF
--- a/compiler/tlgen/generator_test.go
+++ b/compiler/tlgen/generator_test.go
@@ -24,11 +24,12 @@ func TestGoType(t *testing.T) {
 		{"Vector<int>", "[]int32"},
 		{"Vector<long>", "[]int64"},
 		{"Vector<string>", "[]string"},
+		{"vector<future_salt>", "[]*FutureSalt"},
 		{"Type", "TLObject"},
 	}
 
 	for _, tt := range tests {
-		got := goType(tt.tlType, "types", nil, nil)
+		got := goType(tt.tlType, "types", nil, map[string][]Combinator{"FutureSalt": {{QualName: "future_salt"}}})
 		if got != tt.want {
 			t.Errorf("goType(%q) = %q, want %q", tt.tlType, got, tt.want)
 		}
@@ -134,6 +135,74 @@ func TestWriteExpr(t *testing.T) {
 		got := writeExpr(tt.arg, tt.goType, "v")
 		if got != tt.want {
 			t.Errorf("writeExpr(%+v, %q) = %q, want %q", tt.arg, tt.goType, got, tt.want)
+		}
+	}
+}
+
+func TestWriteExprBareVectorConstructor(t *testing.T) {
+	arg := Arg{Name: "salts", Type: "vector<future_salt>"}
+	typeToConstructor := map[string][]Combinator{
+		"FutureSalt": {{
+			QualName: "future_salt",
+			Type:     "FutureSalt",
+			Args: []Arg{
+				{Name: "valid_since", Type: "int", FlagBit: -1},
+				{Name: "valid_until", Type: "int", FlagBit: -1},
+				{Name: "salt", Type: "long", FlagBit: -1},
+			},
+		}},
+	}
+
+	got := writeExpr(arg, "[]*FutureSalt", "v", typeToConstructor)
+	if strings.Contains(got, "0x1cb5c415") {
+		t.Fatalf("bare vector write should not include vector constructor: %s", got)
+	}
+	if strings.Contains(got, "EncodeTLObject") {
+		t.Fatalf("bare vector element write should not use boxed object encoding: %s", got)
+	}
+	for _, want := range []string{"WriteInt(b, uint32(len(v.Salts)))", "_item.ValidSince", "_item.ValidUntil", "_item.Salt"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("writeExpr missing %q in %s", want, got)
+		}
+	}
+}
+
+func TestBareVectorBoxedElements(t *testing.T) {
+	arg := Arg{Name: "ips", Type: "vector<IpPort>"}
+
+	write := writeExpr(arg, "[]IpPortClass", "v", nil)
+	if strings.Contains(write, "0x1cb5c415") {
+		t.Fatalf("bare vector write should not include vector constructor: %s", write)
+	}
+	if !strings.Contains(write, "EncodeTLObject") {
+		t.Fatalf("boxed vector elements should use TL object encoding: %s", write)
+	}
+
+	read := buildReadExpr(arg, "[]IpPortClass", nil, nil)
+	if strings.Contains(read, "_vhdr") {
+		t.Fatalf("bare vector read should not include vector header: %s", read)
+	}
+	if !strings.Contains(read, "ReadTLObject(r)") || !strings.Contains(read, ".(IpPortClass)") {
+		t.Fatalf("boxed vector elements should use TL object decoding: %s", read)
+	}
+	if strings.Index(read, "if _errIps != nil") > strings.Index(read, "_objIps.(IpPortClass)") {
+		t.Fatalf("read error should be checked before type assertion: %s", read)
+	}
+}
+
+func TestBuildReadExprBareVectorConstructor(t *testing.T) {
+	arg := Arg{Name: "salts", Type: "vector<future_salt>"}
+	typeToConstructor := map[string][]Combinator{
+		"FutureSalt": {{QualName: "future_salt", Type: "FutureSalt"}},
+	}
+
+	got := buildReadExpr(arg, "[]*FutureSalt", nil, typeToConstructor)
+	if strings.Contains(got, "_vhdr") || strings.Contains(got, "ReadTLObject") {
+		t.Fatalf("bare vector read should not use boxed vector/object decoding: %s", got)
+	}
+	for _, want := range []string{"_cntSalts", "checkVectorCount", "DecodeFutureSalt(r)"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("buildReadExpr missing %q in %s", want, got)
 		}
 	}
 }

--- a/compiler/tlgen/helpers.go
+++ b/compiler/tlgen/helpers.go
@@ -478,7 +478,7 @@ func buildTypeData(c Combinator, section string, baseTypes map[string]bool, type
 
 		fields = append(fields, fd)
 
-		wl := buildWriteLine(arg, fd, section, baseTypes)
+		wl := buildWriteLine(arg, fd, section, baseTypes, typeToConstructor)
 		writeLines = append(writeLines, wl)
 
 		rl := buildReadLine(arg, fd, section, baseTypes, typeToConstructor)
@@ -527,7 +527,96 @@ func isDirectOptionalScalar(goType string) bool {
 	return false
 }
 
-func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]bool) writeLine {
+func bareVectorInner(tlType string) (string, bool) {
+	if strings.HasPrefix(tlType, "vector<") && strings.HasSuffix(tlType, ">") {
+		return strings.TrimSuffix(strings.TrimPrefix(tlType, "vector<"), ">"), true
+	}
+	return "", false
+}
+
+func constructorByQualName(name string, typeToConstructor map[string][]Combinator) (Combinator, bool) {
+	if typeToConstructor == nil {
+		return Combinator{}, false
+	}
+	stripped := stripNamespace(name)
+	for _, constructors := range typeToConstructor {
+		for _, c := range constructors {
+			if c.QualName == name || c.QualName == stripped || stripNamespace(c.QualName) == stripped {
+				return c, true
+			}
+		}
+	}
+	return Combinator{}, false
+}
+
+func writeBareVectorExpr(inner, access string, typeToConstructor map[string][]Combinator) string {
+	switch stripNamespace(inner) {
+	case "int":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteInt(b, uint32(_item)) }", access, access)
+	case "long":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteLong(b, _item) }", access, access)
+	case "string":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteString(b, _item) }", access, access)
+	case "bytes":
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { WriteBytes(b, _item) }", access, access)
+	}
+
+	if c, ok := constructorByQualName(inner, typeToConstructor); ok {
+		var body strings.Builder
+		for _, a := range c.Args {
+			if a.Type == "#" && a.Name == "flags" {
+				body.WriteString("WriteInt(b, uint32(_item.Flags))\n")
+				continue
+			}
+			gt := resolveGoTypeForField(a, "types", nil, typeToConstructor)
+			body.WriteString(writeExpr(a, gt, "_item", typeToConstructor))
+			body.WriteByte('\n')
+		}
+		return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s {\n%s}", access, access, indentCode(strings.TrimRight(body.String(), "\n"), "\t"))
+	}
+
+	return fmt.Sprintf("WriteInt(b, uint32(len(%s))); for _, _item := range %s { EncodeTLObject(b, _item) }", access, access)
+}
+
+func readBareVectorExpr(inner, assign, fname, goType string, typeToConstructor map[string][]Combinator) string {
+	idx := fname
+	elemType := strings.TrimPrefix(goType, "[]")
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "_cnt%s, _ecnt%s := r.ReadUint32()\n", idx, idx)
+	fmt.Fprintf(&buf, "if _ecnt%s != nil { return nil, _ecnt%s }\n", idx, idx)
+	fmt.Fprintf(&buf, "if _err%s := checkVectorCount(_cnt%s); _err%s != nil {\n\treturn nil, _err%s\n}\n", idx, idx, idx, idx)
+	fmt.Fprintf(&buf, "%s = make(%s, _cnt%s)\n", assign, goType, idx)
+	fmt.Fprintf(&buf, "for _i%s := range %s {\n", idx, assign)
+
+	switch stripNamespace(inner) {
+	case "int":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadInt32()\n", idx, idx)
+	case "long":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadInt64()\n", idx, idx)
+	case "string":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadString()\n", idx, idx)
+	case "bytes":
+		fmt.Fprintf(&buf, "\t_item%s, _err%s := r.ReadBytes()\n", idx, idx)
+	default:
+		if c, ok := constructorByQualName(inner, typeToConstructor); ok {
+			fmt.Fprintf(&buf, "\t_item%s, _err%s := Decode%s(r)\n", idx, idx, SnakeToPascal(c.QualName))
+		} else {
+			fmt.Fprintf(&buf, "\t_obj%s, _err%s := ReadTLObject(r)\n", idx, idx)
+			fmt.Fprintf(&buf, "\tif _err%s != nil {\n\t\treturn nil, _err%s\n\t}\n", idx, idx)
+			fmt.Fprintf(&buf, "\t_item%s := %s\n", idx, typeAssertExpr("_obj"+idx, elemType))
+			fmt.Fprintf(&buf, "\t%s[_i%s] = _item%s\n", assign, idx, idx)
+			buf.WriteString("}")
+			return buf.String()
+		}
+	}
+
+	fmt.Fprintf(&buf, "\tif _err%s != nil {\n\t\treturn nil, _err%s\n\t}\n", idx, idx)
+	fmt.Fprintf(&buf, "\t%s[_i%s] = _item%s\n", assign, idx, idx)
+	buf.WriteString("}")
+	return buf.String()
+}
+
+func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]bool, typeToConstructor map[string][]Combinator) writeLine {
 	wl := writeLine{
 		FlagName: fd.FlagName,
 		FlagBit:  arg.FlagBit,
@@ -537,12 +626,12 @@ func buildWriteLine(arg Arg, fd fieldData, section string, baseTypes map[string]
 		wl.IsGuarded = true
 	}
 
-	wl.Code = writeExpr(arg, fd.GoType, "v")
+	wl.Code = writeExpr(arg, fd.GoType, "v", typeToConstructor)
 
 	return wl
 }
 
-func writeExpr(arg Arg, goType string, receiver string) string {
+func writeExpr(arg Arg, goType string, receiver string, typeMaps ...map[string][]Combinator) string {
 	fieldName := fieldNameFromTL(arg.Name)
 	access := fmt.Sprintf("%s.%s", receiver, fieldName)
 
@@ -550,6 +639,14 @@ func writeExpr(arg Arg, goType string, receiver string) string {
 	deref := access
 	if isPtr {
 		deref = "*" + access
+	}
+
+	var typeToConstructor map[string][]Combinator
+	if len(typeMaps) > 0 {
+		typeToConstructor = typeMaps[0]
+	}
+	if inner, ok := bareVectorInner(arg.Type); ok {
+		return writeBareVectorExpr(inner, access, typeToConstructor)
 	}
 
 	argType := normalizeVectorType(arg.Type)
@@ -619,6 +716,10 @@ func buildReadLine(arg Arg, fd fieldData, section string, baseTypes map[string]b
 func buildReadExpr(arg Arg, goType string, baseTypes map[string]bool, typeToConstructor map[string][]Combinator) string {
 	assign := fmt.Sprintf("v.%s", fieldNameFromTL(arg.Name))
 	fname := fieldNameFromTL(arg.Name)
+	if inner, ok := bareVectorInner(arg.Type); ok {
+		return readBareVectorExpr(inner, assign, fname, goType, typeToConstructor)
+	}
+
 	argType := normalizeVectorType(arg.Type)
 	argType = stripNamespace(argType)
 

--- a/telegram/messages.go
+++ b/telegram/messages.go
@@ -115,7 +115,7 @@ func (c *Client) SendMessage(ctx context.Context, chatID int64, text string, opt
 		flags.Set(14)
 	}
 	if opt.InvertMedia {
-		flags.Set(27)
+		flags.Set(16)
 	}
 
 	var replyTo tg.InputReplyToClass
@@ -365,7 +365,7 @@ func (c *Client) EditMessageText(ctx context.Context, chatID int64, messageID in
 		flags.Set(11)
 	}
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{
@@ -549,7 +549,7 @@ func (c *Client) sendMediaInternal(ctx context.Context, peer tg.InputPeerClass, 
 		flags.Set(14)
 	}
 	if opt.InvertMedia {
-		flags.Set(27)
+		flags.Set(16)
 	}
 
 	var replyTo tg.InputReplyToClass
@@ -848,24 +848,49 @@ func (c *Client) SendMediaGroup(ctx context.Context, chatID int64, items []*tg.I
 	if opt.Background {
 		flags.Set(6)
 	}
+	if opt.ClearDraft {
+		flags.Set(7)
+	}
+	if opt.NoForwards {
+		flags.Set(14)
+	}
+	if opt.InvertMedia {
+		flags.Set(16)
+	}
 
 	var replyTo tg.InputReplyToClass
-	if opt.ReplyToMessageID != 0 {
+	if opt.ReplyTo != nil {
+		flags.Set(0)
+		replyTo = opt.ReplyTo
+	} else if opt.ReplyToMessageID != 0 {
 		flags.Set(0)
 		replyTo = &tg.InputReplyToMessage{ReplyToMsgID: opt.ReplyToMessageID}
+	}
+	if opt.SendAs != nil {
+		flags.Set(13)
+	}
+	if opt.EffectID != nil {
+		flags.Set(18)
 	}
 
 	rpc := c.Raw()
 	req := &tg.MessagesSendMultiMediaRequest{
-		Flags:      flags,
-		Silent:     opt.Silent || opt.DisableNotification,
-		Background: opt.Background,
-		Peer:       peer,
-		ReplyTo:    replyTo,
-		MultiMedia: items,
+		Flags:       flags,
+		Silent:      opt.Silent || opt.DisableNotification,
+		Background:  opt.Background,
+		ClearDraft:  opt.ClearDraft,
+		Noforwards:  opt.NoForwards,
+		InvertMedia: opt.InvertMedia,
+		Peer:        peer,
+		ReplyTo:     replyTo,
+		MultiMedia:  items,
+		SendAs:      opt.SendAs,
 	}
 	if opt.ScheduleDate != nil {
 		req.ScheduleDate = *opt.ScheduleDate
+	}
+	if opt.EffectID != nil {
+		req.Effect = *opt.EffectID
 	}
 	result, err := rpc.MessagesSendMultiMedia(ctx, req)
 	if err != nil {

--- a/telegram/messages_edit.go
+++ b/telegram/messages_edit.go
@@ -47,7 +47,7 @@ func (c *Client) EditMessageCaption(ctx context.Context, chatID int64, messageID
 	var flags tg.Fields
 	flags.Set(11)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{
@@ -108,9 +108,9 @@ func (c *Client) EditMessageMedia(ctx context.Context, chatID int64, messageID i
 	opt := params.GetOptDef(&params.EditMessage{}, opts...)
 
 	var flags tg.Fields
-	flags.Set(13)
+	flags.Set(14)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{

--- a/telegram/messages_edit_inline.go
+++ b/telegram/messages_edit_inline.go
@@ -19,13 +19,13 @@ func (c *Client) EditInlineText(ctx context.Context, inlineMessageID tg.InputBot
 
 	var flags tg.Fields
 	if opt.NoWebpage {
-		flags.Set(0)
+		flags.Set(1)
 	}
 	if text != "" {
 		flags.Set(11)
 	}
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)
@@ -64,7 +64,7 @@ func (c *Client) EditInlineCaption(ctx context.Context, inlineMessageID tg.Input
 	var flags tg.Fields
 	flags.Set(11)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)
@@ -97,9 +97,9 @@ func (c *Client) EditInlineMedia(ctx context.Context, inlineMessageID tg.InputBo
 	opt := getEditInlineOpts(opts...)
 
 	var flags tg.Fields
-	flags.Set(13)
+	flags.Set(14)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)

--- a/telegram/messages_test.go
+++ b/telegram/messages_test.go
@@ -110,6 +110,31 @@ func TestCopyMessages(t *testing.T) {
 	}
 }
 
+func TestSendMessageProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	_, err := c.SendMessage(context.Background(), 10, "hello",
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendMessage() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMessageRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
 func TestEditMessageCaption(t *testing.T) {
 	c, inv := newClientWithMock(t)
 	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
@@ -846,6 +871,164 @@ func TestSendCachedMedia(t *testing.T) {
 	_, ok = req.Media.(*tg.InputMediaDocument)
 	if !ok {
 		t.Fatalf("expected InputMediaDocument, got %T", req.Media)
+	}
+}
+
+func TestSendCachedMediaProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+	cachedFileID, err := fileid.Encode(fileid.FileID{
+		Type:          fileid.FileTypeDocument,
+		DCID:          4,
+		ID:            100,
+		AccessHash:    200,
+		FileReference: []byte{1, 2, 3},
+	})
+	if err != nil {
+		t.Fatalf("encode file_id: %v", err)
+	}
+
+	_, err = c.SendCachedMedia(context.Background(), 10, cachedFileID,
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendCachedMedia() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMediaRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMediaRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
+func TestSendMediaGroupProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	items := []*tg.InputSingleMedia{
+		{
+			Media: &tg.InputMediaPhoto{
+				ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+			},
+			RandomID: 1,
+			Message:  "caption",
+		},
+	}
+	_, err := c.SendMediaGroup(context.Background(), 10, items,
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendMediaGroup() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMultiMediaRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMultiMediaRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditMessageInvertMediaFlag(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	_, err := c.EditMessageText(context.Background(), 10, 55, "edited",
+		&params.EditMessage{InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("EditMessageText() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesEditMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditMessageRequest, got %T", inv.lastCall())
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(26) {
+		t.Fatalf("unexpected stale invert_media flag 26, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditMessageMediaFlag(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	media := &tg.InputMediaPhoto{
+		ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+	}
+	_, err := c.EditMessageMedia(context.Background(), 10, 55, media)
+	if err != nil {
+		t.Fatalf("EditMessageMedia() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesEditMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditMessageRequest, got %T", inv.lastCall())
+	}
+	if req.Media == nil || !req.Flags.Has(14) {
+		t.Fatalf("expected media flag 14, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(13) {
+		t.Fatalf("unexpected stale media flag 13, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditInlineFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	inv.setResult(tg.MessagesEditInlineBotMessageTypeID, &tg.BoolTrue{})
+	inlineID := &tg.InputBotInlineMessageID{DCID: 1, ID: 2, AccessHash: 3}
+
+	_, err := c.EditInlineText(context.Background(), inlineID, "edited",
+		&EditInlineOpts{NoWebpage: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("EditInlineText() error: %v", err)
+	}
+	textReq, ok := inv.lastCall().(*tg.MessagesEditInlineBotMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditInlineBotMessageRequest, got %T", inv.lastCall())
+	}
+	if !textReq.Flags.Has(1) {
+		t.Fatalf("expected no_webpage flag 1, flags=%032b", textReq.Flags)
+	}
+	if !textReq.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", textReq.Flags)
+	}
+	if textReq.Flags.Has(0) || textReq.Flags.Has(26) {
+		t.Fatalf("unexpected stale inline text flags, flags=%032b", textReq.Flags)
+	}
+
+	media := &tg.InputMediaPhoto{
+		ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+	}
+	_, err = c.EditInlineMedia(context.Background(), inlineID, media)
+	if err != nil {
+		t.Fatalf("EditInlineMedia() error: %v", err)
+	}
+	mediaReq, ok := inv.lastCall().(*tg.MessagesEditInlineBotMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditInlineBotMessageRequest, got %T", inv.lastCall())
+	}
+	if mediaReq.Media == nil || !mediaReq.Flags.Has(14) {
+		t.Fatalf("expected media flag 14, flags=%032b", mediaReq.Flags)
+	}
+	if mediaReq.Flags.Has(13) {
+		t.Fatalf("unexpected stale inline media flag 13, flags=%032b", mediaReq.Flags)
 	}
 }
 

--- a/tg/core_types_gen.go
+++ b/tg/core_types_gen.go
@@ -12660,10 +12660,11 @@ func (v *FutureSalts) Encode(b *bytes.Buffer) error {
 	WriteInt(b, FutureSaltsTypeID)
 	WriteLong(b, v.ReqMsgID)
 	WriteInt(b, uint32(v.Now))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Salts)))
 	for _, _item := range v.Salts {
-		EncodeTLObject(b, _item)
+		WriteInt(b, uint32(_item.ValidSince))
+		WriteInt(b, uint32(_item.ValidUntil))
+		WriteLong(b, _item.Salt)
 	}
 	return nil
 }
@@ -12681,10 +12682,6 @@ func DecodeFutureSalts(r *Reader) (*FutureSalts, error) {
 		return nil, _eNow
 	}
 	v.Now = _rNow
-	_vhdrSalts, _ehdrSalts := r.ReadUint32()
-	if _ehdrSalts != nil {
-		return nil, _ehdrSalts
-	}
 	_cntSalts, _ecntSalts := r.ReadUint32()
 	if _ecntSalts != nil {
 		return nil, _ecntSalts
@@ -12694,13 +12691,12 @@ func DecodeFutureSalts(r *Reader) (*FutureSalts, error) {
 	}
 	v.Salts = make([]*FutureSalt, _cntSalts)
 	for _iSalts := range v.Salts {
-		_objSalts, _errSalts := ReadTLObject(r)
+		_itemSalts, _errSalts := DecodeFutureSalt(r)
 		if _errSalts != nil {
 			return nil, _errSalts
 		}
-		v.Salts[_iSalts] = _objSalts.(*FutureSalt)
+		v.Salts[_iSalts] = _itemSalts
 	}
-	_ = _vhdrSalts
 	return v, nil
 }
 
@@ -13089,7 +13085,6 @@ func (v *AccessPointRule) Encode(b *bytes.Buffer) error {
 	WriteInt(b, AccessPointRuleTypeID)
 	WriteString(b, v.PhonePrefixRules)
 	WriteInt(b, uint32(v.DCID))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Ips)))
 	for _, _item := range v.Ips {
 		EncodeTLObject(b, _item)
@@ -13110,10 +13105,6 @@ func DecodeAccessPointRule(r *Reader) (*AccessPointRule, error) {
 		return nil, _eDCID
 	}
 	v.DCID = _rDCID
-	_vhdrIps, _ehdrIps := r.ReadUint32()
-	if _ehdrIps != nil {
-		return nil, _ehdrIps
-	}
 	_cntIps, _ecntIps := r.ReadUint32()
 	if _ecntIps != nil {
 		return nil, _ecntIps
@@ -13127,9 +13118,9 @@ func DecodeAccessPointRule(r *Reader) (*AccessPointRule, error) {
 		if _errIps != nil {
 			return nil, _errIps
 		}
-		v.Ips[_iIps] = _objIps.(IpPortClass)
+		_itemIps := _objIps.(IpPortClass)
+		v.Ips[_iIps] = _itemIps
 	}
-	_ = _vhdrIps
 	return v, nil
 }
 

--- a/tg/help_types_gen.go
+++ b/tg/help_types_gen.go
@@ -2206,7 +2206,6 @@ func (v *HelpConfigSimple) Encode(b *bytes.Buffer) error {
 	WriteInt(b, HelpConfigSimpleTypeID)
 	WriteInt(b, uint32(v.Date))
 	WriteInt(b, uint32(v.Expires))
-	WriteInt(b, 0x1cb5c415)
 	WriteInt(b, uint32(len(v.Rules)))
 	for _, _item := range v.Rules {
 		EncodeTLObject(b, _item)
@@ -2227,10 +2226,6 @@ func DecodeHelpConfigSimple(r *Reader) (*HelpConfigSimple, error) {
 		return nil, _eExpires
 	}
 	v.Expires = _rExpires
-	_vhdrRules, _ehdrRules := r.ReadUint32()
-	if _ehdrRules != nil {
-		return nil, _ehdrRules
-	}
 	_cntRules, _ecntRules := r.ReadUint32()
 	if _ecntRules != nil {
 		return nil, _ecntRules
@@ -2244,9 +2239,9 @@ func DecodeHelpConfigSimple(r *Reader) (*HelpConfigSimple, error) {
 		if _errRules != nil {
 			return nil, _errRules
 		}
-		v.Rules[_iRules] = _objRules.(*AccessPointRule)
+		_itemRules := _objRules.(*AccessPointRule)
+		v.Rules[_iRules] = _itemRules
 	}
-	_ = _vhdrRules
 	return v, nil
 }
 

--- a/tg/message_test.go
+++ b/tg/message_test.go
@@ -35,11 +35,33 @@ func TestMessage_ConstructorID(t *testing.T) {
 	}
 }
 
+func TestDecodeFutureSaltsBareVector(t *testing.T) {
+	var buf bytes.Buffer
+	WriteLong(&buf, 1)
+	WriteInt(&buf, 2)
+	WriteInt(&buf, 1)
+	WriteInt(&buf, 1780476673)
+	WriteInt(&buf, 1780480273)
+	WriteLong(&buf, 0x1122334455667788)
+
+	r := NewReader(buf.Bytes())
+	defer ReleaseReader(r)
+	got, err := DecodeFutureSalts(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Salts) != 1 {
+		t.Fatalf("len(got.Salts) = %d, want 1", len(got.Salts))
+	}
+	if got.Salts[0].ValidSince != 1780476673 || got.Salts[0].ValidUntil != 1780480273 || got.Salts[0].Salt != 0x1122334455667788 {
+		t.Fatalf("unexpected salt: %+v", got.Salts[0])
+	}
+}
+
 func TestDecodeFutureSaltsRejectsHugeVector(t *testing.T) {
 	var buf bytes.Buffer
 	WriteLong(&buf, 1)
 	WriteInt(&buf, 2)
-	WriteInt(&buf, vectorBareID)
 	WriteInt(&buf, maxVectorElements+1)
 
 	r := NewReader(buf.Bytes())


### PR DESCRIPTION
## Summary

This PR aligns mtgo's high-level message/media send and edit helpers with the current [Telegram MTProto Layer 225 schema.](https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/SourceFiles/mtproto/scheme/api.tl)


It fixes incorrect manual flag bits for `invert_media`, `media`, and `no_webpage`, and ensures grouped media sends correctly propagate content protection and other send options.

## Problem

Several high-level helpers manually set request flags before constructing generated `tg.Messages*Request` values. Some of those handwritten bits were stale or incorrect:

- `invert_media` was set as flag 27 in send paths.
- `invert_media` was set as flag 26 in edit paths.
- `media` was set as flag 13 in edit media helpers.
- inline edit `no_webpage` was set as flag 0.
- `SendMediaGroup` did not pass several `params.SendMessage` options into `messages.sendMultiMedia`, including `NoForwards`.

Because generated request `Encode()` calls `SetFlags()` by adding flags from populated fields, it does not clear stale bits that were already manually set. That means a wrong handwritten bit remains serialized together with the correct generated bit.

## Official MTProto Mapping

According to the official Telegram MTProto schema:

- `messages.sendMessage`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.sendMedia`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.sendMultiMedia`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.editMessage`
  - `no_webpage: flags.1`
  - `message: flags.11`
  - `media: flags.14`
  - `invert_media: flags.16`

- `messages.editInlineBotMessage`
  - `no_webpage: flags.1`
  - `message: flags.11`
  - `media: flags.14`
  - `invert_media: flags.16`

## Changes

- Fixed `SendMessage` to set `InvertMedia` with flag 16.
- Fixed cached/single media sends to set `InvertMedia` with flag 16.
- Fixed `SendMediaGroup` to:
  - set `NoForwards` with flag 14
  - set `InvertMedia` with flag 16
  - pass `ClearDraft`
  - pass `ReplyTo`
  - pass `SendAs`
  - pass `EffectID`
- Fixed `EditMessageText` and caption/media edit helpers to set `InvertMedia` with flag 16.
- Fixed `EditMessageMedia` to mark media with flag 14.
- Fixed inline edit helpers:
  - `NoWebpage` now uses flag 1
  - `Media` now uses flag 14
  - `InvertMedia` now uses flag 16
- Added regression tests that assert correct flags and reject stale wrong bits.

## Notes

`ProtectContent` is a Bot API naming concept. In MTProto requests, the corresponding content-protection control for bot sends is `noforwards`. This PR keeps using `NoForwards` as the MTProto-level option.