### PR TITLE
fix(telegram):MTProto media send and edit flags

### DIFF
--- a/telegram/messages.go
+++ b/telegram/messages.go
@@ -115,7 +115,7 @@ func (c *Client) SendMessage(ctx context.Context, chatID int64, text string, opt
 		flags.Set(14)
 	}
 	if opt.InvertMedia {
-		flags.Set(27)
+		flags.Set(16)
 	}
 
 	var replyTo tg.InputReplyToClass
@@ -365,7 +365,7 @@ func (c *Client) EditMessageText(ctx context.Context, chatID int64, messageID in
 		flags.Set(11)
 	}
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{
@@ -549,7 +549,7 @@ func (c *Client) sendMediaInternal(ctx context.Context, peer tg.InputPeerClass, 
 		flags.Set(14)
 	}
 	if opt.InvertMedia {
-		flags.Set(27)
+		flags.Set(16)
 	}
 
 	var replyTo tg.InputReplyToClass
@@ -848,24 +848,49 @@ func (c *Client) SendMediaGroup(ctx context.Context, chatID int64, items []*tg.I
 	if opt.Background {
 		flags.Set(6)
 	}
+	if opt.ClearDraft {
+		flags.Set(7)
+	}
+	if opt.NoForwards {
+		flags.Set(14)
+	}
+	if opt.InvertMedia {
+		flags.Set(16)
+	}
 
 	var replyTo tg.InputReplyToClass
-	if opt.ReplyToMessageID != 0 {
+	if opt.ReplyTo != nil {
+		flags.Set(0)
+		replyTo = opt.ReplyTo
+	} else if opt.ReplyToMessageID != 0 {
 		flags.Set(0)
 		replyTo = &tg.InputReplyToMessage{ReplyToMsgID: opt.ReplyToMessageID}
+	}
+	if opt.SendAs != nil {
+		flags.Set(13)
+	}
+	if opt.EffectID != nil {
+		flags.Set(18)
 	}
 
 	rpc := c.Raw()
 	req := &tg.MessagesSendMultiMediaRequest{
-		Flags:      flags,
-		Silent:     opt.Silent || opt.DisableNotification,
-		Background: opt.Background,
-		Peer:       peer,
-		ReplyTo:    replyTo,
-		MultiMedia: items,
+		Flags:       flags,
+		Silent:      opt.Silent || opt.DisableNotification,
+		Background:  opt.Background,
+		ClearDraft:  opt.ClearDraft,
+		Noforwards:  opt.NoForwards,
+		InvertMedia: opt.InvertMedia,
+		Peer:        peer,
+		ReplyTo:     replyTo,
+		MultiMedia:  items,
+		SendAs:      opt.SendAs,
 	}
 	if opt.ScheduleDate != nil {
 		req.ScheduleDate = *opt.ScheduleDate
+	}
+	if opt.EffectID != nil {
+		req.Effect = *opt.EffectID
 	}
 	result, err := rpc.MessagesSendMultiMedia(ctx, req)
 	if err != nil {

--- a/telegram/messages_edit.go
+++ b/telegram/messages_edit.go
@@ -47,7 +47,7 @@ func (c *Client) EditMessageCaption(ctx context.Context, chatID int64, messageID
 	var flags tg.Fields
 	flags.Set(11)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{
@@ -108,9 +108,9 @@ func (c *Client) EditMessageMedia(ctx context.Context, chatID int64, messageID i
 	opt := params.GetOptDef(&params.EditMessage{}, opts...)
 
 	var flags tg.Fields
-	flags.Set(13)
+	flags.Set(14)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 
 	req := &tg.MessagesEditMessageRequest{

--- a/telegram/messages_edit_inline.go
+++ b/telegram/messages_edit_inline.go
@@ -19,13 +19,13 @@ func (c *Client) EditInlineText(ctx context.Context, inlineMessageID tg.InputBot
 
 	var flags tg.Fields
 	if opt.NoWebpage {
-		flags.Set(0)
+		flags.Set(1)
 	}
 	if text != "" {
 		flags.Set(11)
 	}
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)
@@ -64,7 +64,7 @@ func (c *Client) EditInlineCaption(ctx context.Context, inlineMessageID tg.Input
 	var flags tg.Fields
 	flags.Set(11)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)
@@ -97,9 +97,9 @@ func (c *Client) EditInlineMedia(ctx context.Context, inlineMessageID tg.InputBo
 	opt := getEditInlineOpts(opts...)
 
 	var flags tg.Fields
-	flags.Set(13)
+	flags.Set(14)
 	if opt.InvertMedia {
-		flags.Set(26)
+		flags.Set(16)
 	}
 	if opt.ReplyMarkup != nil {
 		flags.Set(2)

--- a/telegram/messages_test.go
+++ b/telegram/messages_test.go
@@ -110,6 +110,31 @@ func TestCopyMessages(t *testing.T) {
 	}
 }
 
+func TestSendMessageProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	_, err := c.SendMessage(context.Background(), 10, "hello",
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendMessage() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMessageRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
 func TestEditMessageCaption(t *testing.T) {
 	c, inv := newClientWithMock(t)
 	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
@@ -846,6 +871,164 @@ func TestSendCachedMedia(t *testing.T) {
 	_, ok = req.Media.(*tg.InputMediaDocument)
 	if !ok {
 		t.Fatalf("expected InputMediaDocument, got %T", req.Media)
+	}
+}
+
+func TestSendCachedMediaProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+	cachedFileID, err := fileid.Encode(fileid.FileID{
+		Type:          fileid.FileTypeDocument,
+		DCID:          4,
+		ID:            100,
+		AccessHash:    200,
+		FileReference: []byte{1, 2, 3},
+	})
+	if err != nil {
+		t.Fatalf("encode file_id: %v", err)
+	}
+
+	_, err = c.SendCachedMedia(context.Background(), 10, cachedFileID,
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendCachedMedia() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMediaRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMediaRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
+func TestSendMediaGroupProtectionAndInvertMediaFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	items := []*tg.InputSingleMedia{
+		{
+			Media: &tg.InputMediaPhoto{
+				ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+			},
+			RandomID: 1,
+			Message:  "caption",
+		},
+	}
+	_, err := c.SendMediaGroup(context.Background(), 10, items,
+		&params.SendMessage{NoForwards: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("SendMediaGroup() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesSendMultiMediaRequest)
+	if !ok {
+		t.Fatalf("expected MessagesSendMultiMediaRequest, got %T", inv.lastCall())
+	}
+	if !req.Noforwards || !req.Flags.Has(14) {
+		t.Fatalf("expected noforwards flag 14, flags=%032b", req.Flags)
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(27) {
+		t.Fatalf("unexpected stale invert_media flag 27, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditMessageInvertMediaFlag(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	_, err := c.EditMessageText(context.Background(), 10, 55, "edited",
+		&params.EditMessage{InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("EditMessageText() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesEditMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditMessageRequest, got %T", inv.lastCall())
+	}
+	if !req.InvertMedia || !req.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(26) {
+		t.Fatalf("unexpected stale invert_media flag 26, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditMessageMediaFlag(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	c.CachePeer(10, &tg.InputPeerChannel{ChannelID: 10, AccessHash: 20})
+
+	media := &tg.InputMediaPhoto{
+		ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+	}
+	_, err := c.EditMessageMedia(context.Background(), 10, 55, media)
+	if err != nil {
+		t.Fatalf("EditMessageMedia() error: %v", err)
+	}
+	req, ok := inv.lastCall().(*tg.MessagesEditMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditMessageRequest, got %T", inv.lastCall())
+	}
+	if req.Media == nil || !req.Flags.Has(14) {
+		t.Fatalf("expected media flag 14, flags=%032b", req.Flags)
+	}
+	if req.Flags.Has(13) {
+		t.Fatalf("unexpected stale media flag 13, flags=%032b", req.Flags)
+	}
+}
+
+func TestEditInlineFlags(t *testing.T) {
+	c, inv := newClientWithMock(t)
+	inv.setResult(tg.MessagesEditInlineBotMessageTypeID, &tg.BoolTrue{})
+	inlineID := &tg.InputBotInlineMessageID{DCID: 1, ID: 2, AccessHash: 3}
+
+	_, err := c.EditInlineText(context.Background(), inlineID, "edited",
+		&EditInlineOpts{NoWebpage: true, InvertMedia: true},
+	)
+	if err != nil {
+		t.Fatalf("EditInlineText() error: %v", err)
+	}
+	textReq, ok := inv.lastCall().(*tg.MessagesEditInlineBotMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditInlineBotMessageRequest, got %T", inv.lastCall())
+	}
+	if !textReq.Flags.Has(1) {
+		t.Fatalf("expected no_webpage flag 1, flags=%032b", textReq.Flags)
+	}
+	if !textReq.Flags.Has(16) {
+		t.Fatalf("expected invert_media flag 16, flags=%032b", textReq.Flags)
+	}
+	if textReq.Flags.Has(0) || textReq.Flags.Has(26) {
+		t.Fatalf("unexpected stale inline text flags, flags=%032b", textReq.Flags)
+	}
+
+	media := &tg.InputMediaPhoto{
+		ID: &tg.InputPhoto{ID: 1, AccessHash: 2, FileReference: []byte{}},
+	}
+	_, err = c.EditInlineMedia(context.Background(), inlineID, media)
+	if err != nil {
+		t.Fatalf("EditInlineMedia() error: %v", err)
+	}
+	mediaReq, ok := inv.lastCall().(*tg.MessagesEditInlineBotMessageRequest)
+	if !ok {
+		t.Fatalf("expected MessagesEditInlineBotMessageRequest, got %T", inv.lastCall())
+	}
+	if mediaReq.Media == nil || !mediaReq.Flags.Has(14) {
+		t.Fatalf("expected media flag 14, flags=%032b", mediaReq.Flags)
+	}
+	if mediaReq.Flags.Has(13) {
+		t.Fatalf("unexpected stale inline media flag 13, flags=%032b", mediaReq.Flags)
 	}
 }
 


### PR DESCRIPTION
## Summary

This PR aligns mtgo's high-level message/media send and edit helpers with the current [Telegram MTProto Layer 225 schema.](https://github.com/telegramdesktop/tdesktop/blob/dev/Telegram/SourceFiles/mtproto/scheme/api.tl)


It fixes incorrect manual flag bits for `invert_media`, `media`, and `no_webpage`, and ensures grouped media sends correctly propagate content protection and other send options.

## Problem

Several high-level helpers manually set request flags before constructing generated `tg.Messages*Request` values. Some of those handwritten bits were stale or incorrect:

- `invert_media` was set as flag 27 in send paths.
- `invert_media` was set as flag 26 in edit paths.
- `media` was set as flag 13 in edit media helpers.
- inline edit `no_webpage` was set as flag 0.
- `SendMediaGroup` did not pass several `params.SendMessage` options into `messages.sendMultiMedia`, including `NoForwards`.

Because generated request `Encode()` calls `SetFlags()` by adding flags from populated fields, it does not clear stale bits that were already manually set. That means a wrong handwritten bit remains serialized together with the correct generated bit.

## Official MTProto Mapping

According to the official Telegram MTProto schema:

- `messages.sendMessage`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.sendMedia`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.sendMultiMedia`
  - `noforwards: flags.14`
  - `invert_media: flags.16`

- `messages.editMessage`
  - `no_webpage: flags.1`
  - `message: flags.11`
  - `media: flags.14`
  - `invert_media: flags.16`

- `messages.editInlineBotMessage`
  - `no_webpage: flags.1`
  - `message: flags.11`
  - `media: flags.14`
  - `invert_media: flags.16`

## Changes

- Fixed `SendMessage` to set `InvertMedia` with flag 16.
- Fixed cached/single media sends to set `InvertMedia` with flag 16.
- Fixed `SendMediaGroup` to:
  - set `NoForwards` with flag 14
  - set `InvertMedia` with flag 16
  - pass `ClearDraft`
  - pass `ReplyTo`
  - pass `SendAs`
  - pass `EffectID`
- Fixed `EditMessageText` and caption/media edit helpers to set `InvertMedia` with flag 16.
- Fixed `EditMessageMedia` to mark media with flag 14.
- Fixed inline edit helpers:
  - `NoWebpage` now uses flag 1
  - `Media` now uses flag 14
  - `InvertMedia` now uses flag 16
- Added regression tests that assert correct flags and reject stale wrong bits.

## Notes

`ProtectContent` is a Bot API naming concept. In MTProto requests, the corresponding content-protection control for bot sends is `noforwards`. This PR keeps using `NoForwards` as the MTProto-level option.