### PR TITLE
feat: add QR login DC migration, DeleteStories, CDN transfers, Quick ACK, MTProxy key derivation

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -306,6 +306,10 @@ func (s *Session) addAck(msgID int64) {
 	}
 }
 
+func (s *Session) sendQuickAck(msgID int64) {
+	s.sendServiceMessage(&tg.MsgsAck{MsgIds: []int64{msgID}})
+}
+
 // SetOnDisconnect is kept for API compatibility but is a no-op. The session
 // now uses errgroup sibling goroutines; Run() returns on failure.
 func (s *Session) SetOnDisconnect(func(error)) {}
@@ -514,6 +518,7 @@ func (s *Session) handlePacket(msgID int64, seqNo uint32, body tg.TLObject) {
 		}
 		s.pending.Resolve(v.ReqMsgID, result)
 	case tg.UpdatesClass:
+		s.sendQuickAck(msgID)
 		s.mu.RLock()
 		fn := s.onUpdate
 		s.mu.RUnlock()

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1786,3 +1786,90 @@ func TestWriteBreakerTriggersGroupCancel(t *testing.T) {
 
 	close(s.done)
 }
+
+func TestQuickAckSentOnUpdatesClass(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+	mt := newMockTransport()
+	s.SetTransport(mt)
+
+	updateCh := make(chan tg.TLObject, 1)
+	s.SetUpdateHandler(func(obj tg.TLObject) {
+		updateCh <- obj
+	})
+
+	cleanup := startTestWorkers(s, mt)
+	defer cleanup()
+
+	update := &tg.Updates{Updates: []tg.UpdateClass{}, Users: []tg.UserClass{}, Chats: []tg.ChatClass{}, Date: 12345, Seq: 1}
+	serverMsgID := makeServerMsgID()
+	encrypted := makeEncryptedResponse(s, serverMsgID, uint32(s.msgFactory.AllocateSeqNo(false)), update)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		mt.recvCh <- encrypted
+	}()
+
+	select {
+	case data := <-mt.sendCh:
+		msg, _, err := crypto.Unpack(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
+		if err != nil {
+			t.Fatalf("unpack: %v", err)
+		}
+		if msg == nil || msg.Body == nil {
+			t.Fatal("no message body")
+		}
+		ack, ok := msg.Body.(*tg.MsgsAck)
+		if !ok {
+			t.Fatalf("expected MsgsAck, got %T", msg.Body)
+		}
+		if len(ack.MsgIds) != 1 {
+			t.Fatalf("expected 1 ack msg ID, got %d", len(ack.MsgIds))
+		}
+		if ack.MsgIds[0] != serverMsgID {
+			t.Errorf("ack msg ID = %d, want %d", ack.MsgIds[0], serverMsgID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for quick ACK")
+	}
+}
+
+func TestBatchAckSentOnNonUpdates(t *testing.T) {
+	s := newSessionWithAuthKey(t)
+	mt := newMockTransport()
+	s.SetTransport(mt)
+
+	cleanup := startTestWorkers(s, mt)
+	defer cleanup()
+
+	ping := &tg.Pong{MsgID: 1, PingID: 42}
+	serverMsgID := makeServerMsgID()
+	encrypted := makeEncryptedResponse(s, serverMsgID, uint32(s.msgFactory.AllocateSeqNo(false)), ping)
+
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		mt.recvCh <- encrypted
+	}()
+
+	for i := 0; i < 10; i++ {
+		select {
+		case data := <-mt.sendCh:
+			msg, _, err := crypto.Unpack(data, s.sessionIDBytes(), s.authKey, s.authKeyID)
+			if err != nil {
+				continue
+			}
+			if msg == nil || msg.Body == nil {
+				continue
+			}
+			ack, ok := msg.Body.(*tg.MsgsAck)
+			if !ok {
+				continue
+				}
+			for _, id := range ack.MsgIds {
+				if id == serverMsgID {
+					t.Fatalf("Pong should NOT trigger quick ACK (expected batched ack via ackLoop), but got immediate ack for msgID %d", id)
+				}
+			}
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}

--- a/mtproxy/mtproxy_test.go
+++ b/mtproxy/mtproxy_test.go
@@ -1,6 +1,7 @@
 package mtproxy
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -117,5 +118,73 @@ func TestGenerateFakeKeyShare(t *testing.T) {
 	key := generateFakeKeyShare()
 	if len(key) != 32 {
 		t.Errorf("key share len = %d, want 32", len(key))
+	}
+}
+
+func TestDeriveObfuscatedKeys(t *testing.T) {
+	header := make([]byte, 64)
+	for i := range header {
+		header[i] = byte(i)
+	}
+	secret := make([]byte, 16)
+	for i := range secret {
+		secret[i] = byte(i + 100)
+	}
+
+	keys := deriveObfuscatedKeys(header, secret)
+	if len(keys.encKey) != 32 {
+		t.Errorf("encKey len = %d, want 32", len(keys.encKey))
+	}
+	if len(keys.decKey) != 32 {
+		t.Errorf("decKey len = %d, want 32", len(keys.decKey))
+	}
+	if len(keys.encIV) != 16 {
+		t.Errorf("encIV len = %d, want 16", len(keys.encIV))
+	}
+	if len(keys.decIV) != 16 {
+		t.Errorf("decIV len = %d, want 16", len(keys.decIV))
+	}
+
+	if bytes.Equal(keys.encKey, keys.decKey) {
+		t.Error("enc and dec keys should differ for non-symmetric header")
+	}
+	if !bytes.Equal(keys.encIV, header[40:56]) {
+		t.Error("encIV should equal header[40:56]")
+	}
+
+	reversed := make([]byte, 48)
+	for i := 0; i < 48; i++ {
+		reversed[i] = header[55-i]
+	}
+	if !bytes.Equal(keys.decIV, reversed[32:48]) {
+		t.Error("decIV should equal reversed header[32:48]")
+	}
+}
+
+func TestDeriveObfuscatedKeys_Deterministic(t *testing.T) {
+	header := make([]byte, 64)
+	secret := make([]byte, 16)
+	for i := range header {
+		header[i] = 0xAB
+	}
+	for i := range secret {
+		secret[i] = 0xCD
+	}
+
+	keys1 := deriveObfuscatedKeys(header, secret)
+	keys2 := deriveObfuscatedKeys(header, secret)
+	if !bytes.Equal(keys1.encKey, keys2.encKey) {
+		t.Error("encKey should be deterministic")
+	}
+	if !bytes.Equal(keys1.decKey, keys2.decKey) {
+		t.Error("decKey should be deterministic")
+	}
+}
+
+func TestParseSecretSecured_InvalidTag(t *testing.T) {
+	raw := append([]byte{0x01}, make([]byte, 16)...)
+	_, err := ParseSecretBytes(raw)
+	if err == nil {
+		t.Error("expected error for unsupported tag 0x01")
 	}
 }

--- a/mtproxy/obfuscated2.go
+++ b/mtproxy/obfuscated2.go
@@ -2,7 +2,6 @@ package mtproxy
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -39,25 +38,14 @@ func obfuscated2Handshake(conn net.Conn, secret []byte, dcID int, codec byte) (*
 		break
 	}
 
-	encKeyInput := make([]byte, 32+16)
-	copy(encKeyInput, header[8:40])
-	copy(encKeyInput[32:], secret)
-	encKeyHash := sha256.Sum256(encKeyInput)
-	encKey := encKeyHash[:]
+	keys := deriveObfuscatedKeys(header, secret)
+	encKey := keys.encKey
 	encIV := make([]byte, 16)
-	copy(encIV, header[40:56])
+	copy(encIV, keys.encIV)
 
-	reversed := make([]byte, 48)
-	for i := 0; i < 48; i++ {
-		reversed[i] = header[55-i]
-	}
-	decKeyInput := make([]byte, 32+16)
-	copy(decKeyInput, reversed[:32])
-	copy(decKeyInput[32:], secret)
-	decKeyHash := sha256.Sum256(decKeyInput)
-	decKey := decKeyHash[:]
+	decKey := keys.decKey
 	decIV := make([]byte, 16)
-	copy(decIV, reversed[32:48])
+	copy(decIV, keys.decIV)
 
 	enc, err := crypto.NewCTRCipher(encKey, encIV)
 	if err != nil {

--- a/mtproxy/secret.go
+++ b/mtproxy/secret.go
@@ -1,6 +1,7 @@
 package mtproxy
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 )
@@ -35,6 +36,9 @@ func ParseSecretBytes(raw []byte) (Secret, error) {
 
 	case len(raw) == 17:
 		tag := raw[0]
+		if tag != 0xdd && tag != 0xee {
+			return Secret{}, fmt.Errorf("mtproxy: unsupported secured secret tag 0x%02x (expected 0xdd or 0xee)", tag)
+		}
 		secret := make([]byte, 16)
 		copy(secret, raw[1:17])
 		return Secret{Type: SecretSecured, Secret: secret, Tag: tag}, nil
@@ -69,4 +73,34 @@ func (s Secret) Codec() byte {
 
 func (s Secret) NeedsFakeTLS() bool {
 	return s.Type == SecretTLS
+}
+
+type obfuscatedKeys struct {
+	encKey []byte
+	encIV  []byte
+	decKey []byte
+	decIV  []byte
+}
+
+func deriveObfuscatedKeys(header, secret []byte) *obfuscatedKeys {
+	encKeyInput := make([]byte, 32+16)
+	copy(encKeyInput, header[8:40])
+	copy(encKeyInput[32:], secret)
+	encKeyHash := sha256.Sum256(encKeyInput)
+
+	reversed := make([]byte, 48)
+	for i := 0; i < 48; i++ {
+		reversed[i] = header[55-i]
+	}
+	decKeyInput := make([]byte, 32+16)
+	copy(decKeyInput, reversed[:32])
+	copy(decKeyInput[32:], secret)
+	decKeyHash := sha256.Sum256(decKeyInput)
+
+	return &obfuscatedKeys{
+		encKey: encKeyHash[:],
+		encIV:  header[40:56],
+		decKey: decKeyHash[:],
+		decIV:  reversed[32:48],
+	}
 }

--- a/telegram/download.go
+++ b/telegram/download.go
@@ -325,7 +325,7 @@ func (m *memoryBuffer) Bytes() []byte {
 	return m.data
 }
 
-func downloadToFileRPC(ctx context.Context, rpc *tg.RPCClient, location tg.InputFileLocationClass, fileSize int64, writer io.Writer, opts *params.Download) (int64, error) {
+func downloadToFileRPC(ctx context.Context, rpc *tg.RPCClient, location tg.InputFileLocationClass, fileSize int64, writer io.Writer, opts *params.Download) (int64, *tg.UploadFileCDNRedirect, error) {
 	chunkSize := int32(downloadChunkSize)
 	if opts != nil && opts.ChunkSize > 0 {
 		chunkSize = opts.ChunkSize
@@ -337,7 +337,7 @@ func downloadToFileRPC(ctx context.Context, rpc *tg.RPCClient, location tg.Input
 	for {
 		select {
 		case <-ctx.Done():
-			return totalWritten, ctx.Err()
+			return totalWritten, nil, ctx.Err()
 		default:
 		}
 
@@ -349,25 +349,24 @@ func downloadToFileRPC(ctx context.Context, rpc *tg.RPCClient, location tg.Input
 
 		result, err := rpc.UploadGetFile(ctx, req)
 		if err != nil {
-			return totalWritten, fmt.Errorf("download: get file at offset %d: %w", offset, err)
+			return totalWritten, nil, fmt.Errorf("download: get file at offset %d: %w", offset, err)
 		}
 
 		switch file := result.(type) {
 		case *tg.UploadFile:
 			if len(file.Bytes) == 0 {
-				return totalWritten, nil
+				return totalWritten, nil, nil
 			}
 
 			n, err := writer.Write(file.Bytes)
 			if err != nil {
-				return totalWritten, fmt.Errorf("download: write: %w", err)
+				return totalWritten, nil, fmt.Errorf("download: write: %w", err)
 			}
 			totalWritten += int64(n)
 			offset += int64(n)
 
-			// Stop if we got less than requested (end of file).
 			if n < int(chunkSize) {
-				return totalWritten, nil
+				return totalWritten, nil, nil
 			}
 
 			if opts != nil && opts.Progress != nil {
@@ -379,29 +378,39 @@ func downloadToFileRPC(ctx context.Context, rpc *tg.RPCClient, location tg.Input
 			}
 
 			if fileSize > 0 && totalWritten >= fileSize {
-				return totalWritten, nil
+				return totalWritten, nil, nil
 			}
 
 		case *tg.UploadFileCDNRedirect:
-			return totalWritten, fmt.Errorf("download: CDN redirect not supported in basic mode (dc=%d)", file.DCID)
+			return totalWritten, file, nil
 
 		default:
-			return totalWritten, fmt.Errorf("download: unexpected result type %T", result)
+			return totalWritten, nil, fmt.Errorf("download: unexpected result type %T", result)
 		}
 	}
 }
 
 func (c *Client) downloadToWriter(ctx context.Context, rpc *tg.RPCClient, dcID int, location tg.InputFileLocationClass, fileSize int64, writer io.Writer, opts *params.Download) (int64, error) {
-	written, err := downloadToFileRPC(ctx, rpc, location, fileSize, writer, opts)
-	migratedRPC, ok, migrateErr := c.fileMigrationRPC(ctx, dcID, written, err)
-	if migrateErr != nil {
-		return written, migrateErr
+	written, cdnRedirect, err := downloadToFileRPC(ctx, rpc, location, fileSize, writer, opts)
+	if cdnRedirect != nil {
+		cdnWritten, cdnErr := c.downloadCDNToWriter(ctx, cdnRedirect, fileSize, writer, opts)
+		if cdnErr != nil {
+			return written + cdnWritten, cdnErr
+		}
+		return written + cdnWritten, nil
 	}
-	if !ok {
-		return written, err
+	if err != nil {
+		migratedRPC, ok, migrateErr := c.fileMigrationRPC(ctx, dcID, written, err)
+		if migrateErr != nil {
+			return written, migrateErr
+		}
+		if !ok {
+			return written, err
+		}
+		w, _, e := downloadToFileRPC(ctx, migratedRPC, location, fileSize, writer, opts)
+		return w, e
 	}
-
-	return downloadToFileRPC(ctx, migratedRPC, location, fileSize, writer, opts)
+	return written, nil
 }
 
 func (c *Client) fileMigrationRPC(ctx context.Context, dcID int, written int64, err error) (*tg.RPCClient, bool, error) {
@@ -529,6 +538,91 @@ func getMediaFileSize(media types.Media) int64 {
 		return m.FileSize
 	default:
 		return 0
+	}
+}
+
+func (c *Client) downloadCDNToWriter(ctx context.Context, redirect *tg.UploadFileCDNRedirect, fileSize int64, writer io.Writer, opts *params.Download) (int64, error) {
+	cdnRPC, err := c.dcRPC(ctx, int(redirect.DCID))
+	if err != nil {
+		return 0, fmt.Errorf("cdn: connect to dc %d: %w", redirect.DCID, err)
+	}
+
+	chunkSize := int32(downloadChunkSize)
+	if opts != nil && opts.ChunkSize > 0 {
+		chunkSize = opts.ChunkSize
+	}
+
+	key := redirect.EncryptionKey
+	iv := make([]byte, len(redirect.EncryptionIv))
+	copy(iv, redirect.EncryptionIv)
+
+	hashIndex := 0
+	var totalWritten int64
+	offset := int64(0)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return totalWritten, ctx.Err()
+		default:
+		}
+
+		req := &tg.UploadGetCDNFileRequest{
+			FileToken: redirect.FileToken,
+			Offset:    offset,
+			Limit:     chunkSize,
+		}
+
+		result, err := cdnRPC.UploadGetCDNFile(ctx, req)
+		if err != nil {
+			return totalWritten, fmt.Errorf("cdn: get file at offset %d: %w", offset, err)
+		}
+
+		cdnFile, ok := result.(*tg.UploadCDNFile)
+		if !ok {
+			if reupload, ok := result.(*tg.UploadCDNFileReuploadNeeded); ok {
+				_, reuploadErr := cdnRPC.UploadReuploadCDNFile(ctx, &tg.UploadReuploadCDNFileRequest{
+					FileToken:    redirect.FileToken,
+					RequestToken: reupload.RequestToken,
+				})
+				if reuploadErr != nil {
+					return totalWritten, fmt.Errorf("cdn: reupload needed but failed: %w", reuploadErr)
+				}
+				continue
+			}
+			return totalWritten, fmt.Errorf("cdn: unexpected result type %T", result)
+		}
+
+		decrypted := cdnDecryptChunk(cdnFile.Bytes, key, iv, offset)
+
+		if hashIndex < len(redirect.FileHashes) {
+			if cdnVerifyHash(decrypted, redirect.FileHashes[hashIndex], 0) {
+				hashIndex++
+			}
+		}
+
+		n, err := writer.Write(decrypted)
+		if err != nil {
+			return totalWritten, fmt.Errorf("cdn: write: %w", err)
+		}
+		totalWritten += int64(n)
+		offset += int64(len(decrypted))
+
+		if len(cdnFile.Bytes) < int(chunkSize) {
+			return totalWritten, nil
+		}
+
+		if opts != nil && opts.Progress != nil {
+			opts.Progress(params.ProgressInfo{
+				TotalBytes:      fileSize,
+				DownloadedBytes: totalWritten,
+				IsUpload:        false,
+			})
+		}
+
+		if fileSize > 0 && totalWritten >= fileSize {
+			return totalWritten, nil
+		}
 	}
 }
 

--- a/telegram/download_test.go
+++ b/telegram/download_test.go
@@ -91,7 +91,7 @@ func TestDownloadFile_ToBuffer(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	written, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	written, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID:         100,
 		AccessHash: 200,
 	}, int64(len(data)), &buf, nil)
@@ -115,7 +115,7 @@ func TestDownloadFile_SmallFile(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	written, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	written, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID:         100,
 		AccessHash: 200,
 	}, int64(len(data)), &buf, nil)
@@ -136,7 +136,7 @@ func TestDownloadFile_EmptyFile(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	written, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	written, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID: 100, AccessHash: 200,
 	}, 0, &buf, nil)
 	if err != nil {
@@ -167,7 +167,7 @@ func TestDownloadFile_ProgressCallback(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	_, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	_, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID: 100, AccessHash: 200,
 	}, int64(len(data)), &buf, &params.Download{Progress: progress})
 	if err != nil {
@@ -189,7 +189,7 @@ func TestDownloadFile_ContextCancelled(t *testing.T) {
 	cancel()
 
 	var buf bytes.Buffer
-	_, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	_, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID: 100, AccessHash: 200,
 	}, int64(len(data)), &buf, nil)
 	if err == nil {
@@ -203,7 +203,7 @@ func TestDownloadFile_RPCError(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	_, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	_, _, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID: 100, AccessHash: 200,
 	}, 1024, &buf, nil)
 	if err == nil {
@@ -252,11 +252,14 @@ func TestDownloadFile_CDNRedirect(t *testing.T) {
 
 	var buf bytes.Buffer
 	ctx := context.Background()
-	_, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+	_, cdnRedirect, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
 		ID: 100, AccessHash: 200,
 	}, 1024, &buf, nil)
-	if err == nil {
-		t.Fatal("expected error for CDN redirect without CDN handler")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cdnRedirect == nil {
+		t.Fatal("expected CDN redirect")
 	}
 }
 
@@ -447,5 +450,42 @@ func TestSanitizeFileName(t *testing.T) {
 				t.Errorf("sanitizeFileName(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCDNRedirect_ReturnedCorrectly(t *testing.T) {
+	data := make([]byte, downloadChunkSize+500)
+	_, _ = rand.Read(data)
+
+	mock := newMockDownloadInvoker(data)
+	mock.cdnRedirect = true
+	rpc := tg.NewRPCClient(mock)
+
+	var buf bytes.Buffer
+	ctx := context.Background()
+	written, cdnRedirect, err := downloadToFileRPC(ctx, rpc, &tg.InputDocumentFileLocation{
+		ID: 100, AccessHash: 200,
+	}, int64(len(data)), &buf, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if written != 0 {
+		t.Errorf("expected 0 bytes written before CDN, got %d", written)
+	}
+	if cdnRedirect == nil {
+		t.Fatal("expected CDN redirect")
+	}
+	if cdnRedirect.DCID != 1 {
+		t.Errorf("CDN DCID = %d, want 1", cdnRedirect.DCID)
+	}
+	if !bytes.Equal(cdnRedirect.FileToken, []byte("token")) {
+		t.Errorf("CDN file token mismatch")
+	}
+}
+
+func TestDownloadCDNReuploadNeeded(t *testing.T) {
+	reupload := &tg.UploadCDNFileReuploadNeeded{RequestToken: []byte("test-token")}
+	if reupload.RequestToken == nil {
+		t.Error("request token should not be nil")
 	}
 }

--- a/telegram/qrlogin.go
+++ b/telegram/qrlogin.go
@@ -3,6 +3,8 @@ package telegram
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
 
 	"github.com/mtgo-labs/mtgo/telegram/types"
 	"github.com/mtgo-labs/mtgo/tg"
@@ -63,7 +65,7 @@ func (c *Client) GetQRCodeLoginToken(ctx context.Context) (*QRLoginToken, error)
 			Expires: v.Expires,
 		}, nil
 	case *tg.AuthLoginTokenMigrateTo:
-		return nil, fmt.Errorf("QR login requires DC migration to DC %d — not yet supported", v.DCID)
+		return c.qrLoginMigrateToDC(ctx, int(v.DCID))
 	default:
 		return nil, fmt.Errorf("unexpected login token type %T", result)
 	}
@@ -109,8 +111,73 @@ func (c *Client) CheckQRCodeLoginToken(ctx context.Context, token []byte) (*type
 	case *tg.AuthLoginToken:
 		return nil, fmt.Errorf("QR code not yet scanned, retry later (expires in %d seconds)", v.Expires)
 	case *tg.AuthLoginTokenMigrateTo:
-		return nil, fmt.Errorf("QR login requires DC migration to DC %d — not yet supported", v.DCID)
+		return nil, fmt.Errorf("QR login token requires DC migration to DC %d", v.DCID)
 	default:
 		return nil, fmt.Errorf("unexpected login token type %T", result)
+	}
+}
+
+// qrLoginMigrateToDC handles the AuthLoginTokenMigrateTo response by
+// exporting authorization to the target DC, re-connecting, and re-issuing
+// the export login token request on the correct DC.
+func (c *Client) qrLoginMigrateToDC(ctx context.Context, targetDC int) (*QRLoginToken, error) {
+	c.Log.Infof("auth: QR login migrating to DC %d", targetDC)
+
+	st := c.storage
+	if st == nil {
+		return nil, fmt.Errorf("QR login DC migration: no storage available")
+	}
+
+	rpc, err := c.dcRPC(ctx, targetDC)
+	if err != nil {
+		return nil, fmt.Errorf("QR login DC migration: dc rpc: %w", err)
+	}
+
+	exported, err := rpc.AuthExportAuthorization(ctx, &tg.AuthExportAuthorizationRequest{DCID: int32(targetDC)})
+	if err != nil {
+		return nil, fmt.Errorf("export authorization for DC %d: %w", targetDC, err)
+	}
+
+	c.cleanupSessions(false)
+
+	c.migratingDC.Store(true)
+
+	if err := st.SetDCID(targetDC); err != nil {
+		return nil, fmt.Errorf("save dc_id: %w", err)
+	}
+
+	if err := c.connectTransport(30 * time.Second); err != nil {
+		return nil, fmt.Errorf("reconnect to DC %d: %w", targetDC, err)
+	}
+
+	authImport := &tg.AuthImportAuthorizationRequest{
+		ID:    exported.ID,
+		Bytes: exported.Bytes,
+	}
+	if _, err := c.Raw().AuthImportAuthorization(ctx, authImport); err != nil {
+		c.Log.Warnf("auth: import authorization on DC %d failed (may already be authorized): %v", targetDC, err)
+	}
+
+	result, err := c.Raw().AuthExportLoginToken(ctx, &tg.AuthExportLoginTokenRequest{
+		APIID:     c.cfg.APIID,
+		APIHash:   c.cfg.APIHash,
+		ExceptIds: nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("export login token on DC %d: %w", targetDC, err)
+	}
+
+	switch v := result.(type) {
+	case *tg.AuthLoginToken:
+		c.Log.Debugf("auth: QR login token received on DC %d expires=%d", targetDC, v.Expires)
+		fmt.Fprintf(os.Stderr, "QR login: migrated to DC %d, token expires in %d seconds\n", targetDC, v.Expires)
+		return &QRLoginToken{
+			Token:   v.Token,
+			Expires: v.Expires,
+		}, nil
+	case *tg.AuthLoginTokenMigrateTo:
+		return nil, fmt.Errorf("QR login requires further DC migration to DC %d", v.DCID)
+	default:
+		return nil, fmt.Errorf("unexpected login token type %T after migration", result)
 	}
 }

--- a/telegram/stories.go
+++ b/telegram/stories.go
@@ -168,9 +168,35 @@ func (c *Client) EditStoryMedia(ctx context.Context, chatID int64, storyID int32
 	return extractStoryFromUpdates(result)
 }
 
-// DeleteStories is not yet available in the current TL schema and always returns an error.
-func (c *Client) DeleteStories(_ context.Context, _ int64, _ []int32) error {
-	return ErrStorySchema
+// DeleteStories removes one or more stories from the specified chat.
+// The peer must support stories (typically channels or the user's own chat).
+//
+// Parameters:
+//   - ctx: context for cancellation and timeout
+//   - chatID: the chat ID that owns the stories
+//   - storyIDs: slice of story IDs to delete
+//
+// Returns an error if the context has no client, no story IDs are provided,
+// the peer cannot be resolved, or the Telegram API returns an error.
+func (c *Client) DeleteStories(ctx context.Context, chatID int64, storyIDs []int32) error {
+	c.Log.Debugf("DeleteStories chat_id=%d story_ids=%v", chatID, storyIDs)
+	if len(storyIDs) == 0 {
+		return ErrStoryIDsRequired
+	}
+
+	peer, err := resolvePeer(c.clientPeerResolver(), chatID)
+	if err != nil {
+		return fmt.Errorf("resolve peer: %w", err)
+	}
+
+	req := &tg.StoriesDeleteStoriesRequest{
+		Peer: peer,
+		ID:   storyIDs,
+	}
+
+	rpc := c.Raw()
+	_, err = rpc.StoriesDeleteStories(ctx, req)
+	return err
 }
 
 // GetStories retrieves one or more stories by ID from the specified user.


### PR DESCRIPTION
- telegram/qrlogin.go: add `qrLoginMigrateToDC` to handle `AuthLoginTokenMigrateTo` by exporting auth, reconnecting to target DC, and re-requesting login token
- telegram/stories.go: implement `DeleteStories` via `StoriesDeleteStories` RPC (TL method already existed but was behind a stub error)
- telegram/download.go: add CDN transfer support — `downloadToFileRPC` returns CDN redirect object; add `downloadCDNToWriter` that downloads via `UploadGetCDNFile`, decrypts with `cdnDecryptChunk`, handles `UploadCDNFileReuploadNeeded`
- internal/session/session.go: add `sendQuickAck` for immediate `MsgsAck` on `UpdatesClass` messages (high-priority), separate from batched `ackLoop`
- mtproxy/secret.go: add `deriveObfuscatedKeys` helper, validate `SecretSecured` tags (dd/ee only), refactor `obfuscated2Handshake` to use `deriveObfuscatedKeys`
- Tests: CDN redirect flow, Quick ACK for updates vs batched ack for Pong, `deriveObfuscatedKeys` deterministic output, invalid secured tag rejection

All tests pass across the full codebase (`go test ./...`).