### PR TITLE
fix(telegram): parse chat member updates

### DIFF
--- a/telegram/client.go
+++ b/telegram/client.go
@@ -1840,9 +1840,9 @@ func (c *Client) toUpdate(raw tg.UpdateClass, users map[int64]*types.User, chats
 			}
 		}
 	case *tg.UpdateChatParticipant:
-		upd.ChatMember = &types.ChatMemberUpdated{}
+		upd.ChatMember = types.ParseChatMemberUpdated(v, userClassesFromPeerMap(pm), pm)
 	case *tg.UpdateChannelParticipant:
-		upd.ChatMember = &types.ChatMemberUpdated{}
+		upd.ChatMember = types.ParseChatMemberUpdated(v, userClassesFromPeerMap(pm), pm)
 	case *tg.UpdateMessageReactions:
 		upd.MessageReaction = &types.MessageReactions{}
 	case *tg.UpdateMessagePoll:
@@ -1961,6 +1961,17 @@ func buildChatMap(chats []tg.ChatClass) map[int64]*types.Chat {
 		}
 	}
 	return m
+}
+
+func userClassesFromPeerMap(pm *types.PeerMap) map[int64]tg.UserClass {
+	if pm == nil || len(pm.Users) == 0 {
+		return nil
+	}
+	users := make(map[int64]tg.UserClass, len(pm.Users))
+	for id, user := range pm.Users {
+		users[id] = user
+	}
+	return users
 }
 
 // ResolvePeer resolves a ChatRef (ID, username, or InputPeer) into an InputPeerClass

--- a/telegram/client_test.go
+++ b/telegram/client_test.go
@@ -1126,6 +1126,58 @@ func TestClientUpdateHealthNoManager(t *testing.T) {
 	}
 }
 
+func TestClientToUpdateParsesChannelParticipantUpdate(t *testing.T) {
+	const (
+		channelID = int64(12345)
+		actorID   = int64(1001)
+		botID     = int64(2002)
+	)
+
+	c, _ := NewClient(1, "hash", nil)
+	rawUsers := []tg.UserClass{
+		&tg.User{ID: actorID, FirstName: "Actor"},
+		&tg.User{ID: botID, FirstName: "Bot", Bot: true},
+	}
+	rawChats := []tg.ChatClass{
+		&tg.Channel{ID: channelID, Title: "Sync"},
+	}
+	raw := &tg.UpdateChannelParticipant{
+		ChannelID: channelID,
+		ActorID:   actorID,
+		UserID:    botID,
+		NewParticipant: &tg.ChannelParticipantAdmin{
+			UserID: botID,
+			AdminRights: &tg.ChatAdminRights{
+				PostMessages: true,
+			},
+		},
+	}
+
+	upd := c.toUpdate(raw, buildUserMap(rawUsers), buildChatMap(rawChats), types.NewPeerMapFromClasses(rawUsers, rawChats))
+
+	if upd.ChatMember == nil {
+		t.Fatal("ChatMember is nil")
+	}
+	if upd.ChatMember.Chat == nil || upd.ChatMember.Chat.ID != types.GetPeerID(&tg.PeerChannel{ChannelID: channelID}) {
+		t.Fatalf("Chat = %+v", upd.ChatMember.Chat)
+	}
+	if upd.ChatMember.FromUser == nil || upd.ChatMember.FromUser.ID != actorID {
+		t.Fatalf("FromUser = %+v", upd.ChatMember.FromUser)
+	}
+	if upd.ChatMember.NewChatMember == nil {
+		t.Fatal("NewChatMember is nil")
+	}
+	if upd.ChatMember.NewChatMember.Status != types.ChatMemberStatusAdministrator {
+		t.Fatalf("Status = %q", upd.ChatMember.NewChatMember.Status)
+	}
+	if upd.ChatMember.NewChatMember.User == nil || upd.ChatMember.NewChatMember.User.ID != botID {
+		t.Fatalf("NewChatMember.User = %+v", upd.ChatMember.NewChatMember.User)
+	}
+	if upd.ChatMember.NewChatMember.Privileges == nil || !upd.ChatMember.NewChatMember.Privileges.CanPostMessages {
+		t.Fatalf("Privileges = %+v", upd.ChatMember.NewChatMember.Privileges)
+	}
+}
+
 type closeTrackingStorage struct {
 	*MemoryStorage
 	closed bool

--- a/telegram/client_test.go
+++ b/telegram/client_test.go
@@ -1126,6 +1126,53 @@ func TestClientUpdateHealthNoManager(t *testing.T) {
 	}
 }
 
+func TestClientToUpdateParsesChatParticipantUpdate(t *testing.T) {
+	const (
+		chatID  = int64(12345)
+		actorID = int64(1001)
+		userID  = int64(2002)
+	)
+
+	c, _ := NewClient(1, "hash", nil)
+	rawUsers := []tg.UserClass{
+		&tg.User{ID: actorID, FirstName: "Actor"},
+		&tg.User{ID: userID, FirstName: "User"},
+	}
+	rawChats := []tg.ChatClass{
+		&tg.Chat{ID: chatID, Title: "Group"},
+	}
+	raw := &tg.UpdateChatParticipant{
+		ChatID: chatID,
+		ActorID: actorID,
+		UserID:  userID,
+		NewParticipant: &tg.ChatParticipantAdmin{
+			UserID:   userID,
+			InviterID: actorID,
+		},
+	}
+
+	upd := c.toUpdate(raw, buildUserMap(rawUsers), buildChatMap(rawChats), types.NewPeerMapFromClasses(rawUsers, rawChats))
+
+	if upd.ChatMember == nil {
+		t.Fatal("ChatMember is nil")
+	}
+	if upd.ChatMember.Chat == nil || upd.ChatMember.Chat.ID != types.GetPeerID(&tg.PeerChat{ChatID: chatID}) {
+		t.Fatalf("Chat = %+v", upd.ChatMember.Chat)
+	}
+	if upd.ChatMember.FromUser == nil || upd.ChatMember.FromUser.ID != actorID {
+		t.Fatalf("FromUser = %+v", upd.ChatMember.FromUser)
+	}
+	if upd.ChatMember.NewChatMember == nil {
+		t.Fatal("NewChatMember is nil")
+	}
+	if upd.ChatMember.NewChatMember.Status != types.ChatMemberStatusAdministrator {
+		t.Fatalf("Status = %q", upd.ChatMember.NewChatMember.Status)
+	}
+	if upd.ChatMember.NewChatMember.User == nil || upd.ChatMember.NewChatMember.User.ID != userID {
+		t.Fatalf("NewChatMember.User = %+v", upd.ChatMember.NewChatMember.User)
+	}
+}
+
 func TestClientToUpdateParsesChannelParticipantUpdate(t *testing.T) {
 	const (
 		channelID = int64(12345)

--- a/telegram/types/chat_member.go
+++ b/telegram/types/chat_member.go
@@ -87,6 +87,9 @@ func ParseChannelParticipant(raw tg.ChannelParticipantClass, users map[int64]tg.
 	if raw == nil {
 		return nil
 	}
+	if p, ok := raw.(*tg.ChannelsChannelParticipant); ok {
+		return ParseChannelParticipant(p.Participant, mergeUserClasses(users, p.Users))
+	}
 	m := &ChatMember{}
 	switch p := raw.(type) {
 	case *tg.ChannelParticipantCreator:
@@ -159,6 +162,22 @@ func getUser(users map[int64]tg.UserClass, id int64) *User {
 		return ParseUser(u)
 	}
 	return nil
+}
+
+func mergeUserClasses(base map[int64]tg.UserClass, users []tg.UserClass) map[int64]tg.UserClass {
+	if len(users) == 0 {
+		return base
+	}
+	merged := make(map[int64]tg.UserClass, len(base)+len(users))
+	for id, user := range base {
+		merged[id] = user
+	}
+	for _, user := range users {
+		if parsed := ParseUser(user); parsed != nil {
+			merged[parsed.ID] = user
+		}
+	}
+	return merged
 }
 
 func getPeerUserID(peer tg.PeerClass) int64 {

--- a/telegram/types/chat_member_test.go
+++ b/telegram/types/chat_member_test.go
@@ -1,0 +1,36 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/mtgo-labs/mtgo/tg"
+)
+
+func TestParseChannelParticipantUnwrapsChannelParticipantResult(t *testing.T) {
+	const userID = int64(2002)
+
+	member := ParseChannelParticipant(&tg.ChannelsChannelParticipant{
+		Participant: &tg.ChannelParticipantAdmin{
+			UserID: userID,
+			AdminRights: &tg.ChatAdminRights{
+				PostMessages: true,
+			},
+		},
+		Users: []tg.UserClass{
+			&tg.User{ID: userID, FirstName: "Bot", Bot: true},
+		},
+	}, nil)
+
+	if member == nil {
+		t.Fatal("member is nil")
+	}
+	if member.Status != ChatMemberStatusAdministrator {
+		t.Fatalf("Status = %q", member.Status)
+	}
+	if member.User == nil || member.User.ID != userID || member.User.FirstName != "Bot" {
+		t.Fatalf("User = %+v", member.User)
+	}
+	if member.Privileges == nil || !member.Privileges.CanPostMessages {
+		t.Fatalf("Privileges = %+v", member.Privileges)
+	}
+}


### PR DESCRIPTION
## Summary

Fix high-level chat member update parsing.

`UpdateChatParticipant` and `UpdateChannelParticipant` were previously recognized by the update mapper, but `Update.ChatMember` was populated with an empty `types.ChatMemberUpdated{}`. As a result, `OnChatMember` handlers received empty/nil chat member data even though the raw TL update contained the correct actor, chat, participant status, and admin rights.

This also fixes `GetChatMember` parsing for `channels.channelParticipant` wrapper responses.

## Changes

- Parse `UpdateChatParticipant` and `UpdateChannelParticipant` with `types.ParseChatMemberUpdated`.
- Derive parser user classes from the existing `PeerMap`, keeping the update delivery path small and avoiding broader update manager changes.
- Unwrap `tg.ChannelsChannelParticipant` in `types.ParseChannelParticipant`.
- Merge users from the wrapper response so participant user data can be resolved correctly.
- Add regression tests for:
  - `toUpdate` populating `ChatMemberUpdated` for channel participant updates.
  - parsing wrapped `channels.channelParticipant` results.