### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directories:
+      - "/"
+      - "/examples/i18n_bot"
+      - "/examples/middleware_bot"
+      - "/examples/mongodb_bot"
+      - "/examples/sqlite_basic"
+    schedule:
+      interval: daily
+    groups:
+      golang:
+        group-by: dependency-name
+        patterns:
+          - "golang.org/x/*"
+      mtgo-labs:
+        group-by: dependency-name
+        patterns:
+          - "github.com/mtgo-labs/*"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily


### PR DESCRIPTION
## Summary
- add Dependabot config adapted from gotd/td
- enable daily Go module updates across the root module and example modules
- enable daily GitHub Actions updates
- group golang.org/x/* and github.com/mtgo-labs/* updates by dependency name across module directories

## Validation
- yq parsed .github/dependabot.yml successfully
- git diff --check passed

Docs referenced: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference