### PR TITLE
ci: limit Dependabot Go updates to root module

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,21 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: gomod
-    directories:
-      - "/"
-      - "/examples/i18n_bot"
-      - "/examples/middleware_bot"
-      - "/examples/mongodb_bot"
-      - "/examples/sqlite_basic"
+    directory: "/"
     schedule:
       interval: daily
     groups:
       golang:
-        group-by: dependency-name
         patterns:
           - "golang.org/x/*"
       mtgo-labs:
-        group-by: dependency-name
         patterns:
           - "github.com/mtgo-labs/*"
 


### PR DESCRIPTION
## Summary
- update Dependabot gomod config to scan only the root module
- remove example module directories from Dependabot
- keep GitHub Actions dependency updates enabled

Example modules will be updated manually.

## Validation
- yq parsed .github/dependabot.yml successfully
- git diff --check passed