### PR TITLE
fix(telegram): use %w for error wrapping and add sentinel errors for …

### DIFF
--- a/session/gramjs.go
+++ b/session/gramjs.go
@@ -50,7 +50,7 @@ func DecodeGramjs(s string) (*SessionData, error) {
 	}
 
 	if len(payload) < 5+256 {
-		return nil, fmt.Errorf("payload too short: %d bytes", len(payload))
+		return nil, fmt.Errorf("%w: %d bytes", errPayloadTooShort, len(payload))
 	}
 
 	dcID := int(payload[0])

--- a/session/mtcute.go
+++ b/session/mtcute.go
@@ -12,6 +12,7 @@ var (
 	errPayloadTooShortForIsBot  = errors.New("payload too short for is_bot")
 	errDCOptionTooShortForPort  = errors.New("DC option too short for port")
 	errNotEnoughBytesForTLLen   = errors.New("not enough bytes for TL length prefix")
+	errPayloadTooShort         = errors.New("payload too short")
 )
 
 // mtcute format uses TL serialization primitives.
@@ -82,7 +83,7 @@ func DecodeMtcute(s string) (*SessionData, error) {
 	}
 
 	if len(payload) < 5 {
-		return nil, fmt.Errorf("payload too short: %d bytes", len(payload))
+		return nil, fmt.Errorf("%w: %d bytes", errPayloadTooShort, len(payload))
 	}
 
 	off := 0

--- a/session/session.go
+++ b/session/session.go
@@ -392,7 +392,7 @@ func DecodeGotgExtended(s string) (*SessionData, error) {
 		return nil, fmt.Errorf("gotg_extended: base64 decode: %w", err)
 	}
 	if len(payload) < 27+256 {
-		return nil, fmt.Errorf("gotg_extended: payload too short: %d", len(payload))
+		return nil, fmt.Errorf("gotg_extended: %w: %d", errPayloadTooShort, len(payload))
 	}
 
 	dc := int(int32(binary.LittleEndian.Uint32(payload[0:4])))

--- a/session/telethon.go
+++ b/session/telethon.go
@@ -83,7 +83,7 @@ func DecodeTelethon(s string) (*SessionData, error) {
 
 func decodeTelethonV1(payload []byte, dcID int) (*SessionData, error) {
 	if len(payload) < 1+4+2+256 {
-		return nil, fmt.Errorf("payload too short: %d bytes", len(payload))
+		return nil, fmt.Errorf("%w: %d bytes", errPayloadTooShort, len(payload))
 	}
 
 	var ipLen int
@@ -114,7 +114,7 @@ func decodeTelethonV1(payload []byte, dcID int) (*SessionData, error) {
 // decodeTelethonV2 decodes: dc_id(1B) + ip(4B|16B) + port(2B) + api_id(4B) + auth_key(256B)
 func decodeTelethonV2(payload []byte, dcID int) (*SessionData, error) {
 	if len(payload) < 1+4+2+4+256 {
-		return nil, fmt.Errorf("payload too short: %d bytes", len(payload))
+		return nil, fmt.Errorf("%w: %d bytes", errPayloadTooShort, len(payload))
 	}
 
 	var ipLen int

--- a/telegram/bound_folders.go
+++ b/telegram/bound_folders.go
@@ -66,7 +66,7 @@ func (c *Client) BoundIncludeChat(folderID int32, chatID int64) error {
 			return c.BoundEditFolder(df)
 		}
 	}
-	return fmt.Errorf("folder %d not found", folderID)
+	return fmt.Errorf("%w: %d", ErrFolderNotFound, folderID)
 }
 
 func (c *Client) BoundExcludeChat(folderID int32, chatID int64) error {
@@ -84,7 +84,7 @@ func (c *Client) BoundExcludeChat(folderID int32, chatID int64) error {
 			return c.BoundEditFolder(df)
 		}
 	}
-	return fmt.Errorf("folder %d not found", folderID)
+	return fmt.Errorf("%w: %d", ErrFolderNotFound, folderID)
 }
 
 func (c *Client) BoundUpdateFolderColor(folderID int32, color int32) error {
@@ -98,7 +98,7 @@ func (c *Client) BoundUpdateFolderColor(folderID int32, color int32) error {
 			return c.BoundEditFolder(df)
 		}
 	}
-	return fmt.Errorf("folder %d not found", folderID)
+	return fmt.Errorf("%w: %d", ErrFolderNotFound, folderID)
 }
 
 func (c *Client) BoundPinChatInFolder(folderID int32, chatID int64) error {
@@ -116,7 +116,7 @@ func (c *Client) BoundPinChatInFolder(folderID int32, chatID int64) error {
 			return c.BoundEditFolder(df)
 		}
 	}
-	return fmt.Errorf("folder %d not found", folderID)
+	return fmt.Errorf("%w: %d", ErrFolderNotFound, folderID)
 }
 
 func (c *Client) BoundRemoveChatFromFolder(folderID int32, chatID int64) error {
@@ -136,7 +136,7 @@ func (c *Client) BoundRemoveChatFromFolder(folderID int32, chatID int64) error {
 			return c.BoundEditFolder(df)
 		}
 	}
-	return fmt.Errorf("folder %d not found", folderID)
+	return fmt.Errorf("%w: %d", ErrFolderNotFound, folderID)
 }
 
 func removePeerFromSlice(peers []tg.InputPeerClass, target tg.InputPeerClass) []tg.InputPeerClass {

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -1116,7 +1116,7 @@ func (c *Client) initSession(st storage.Storage, testSession *session.Session) (
 		IPv6:     c.config().IPv6,
 	}
 	if dc.Address() == "" {
-		return nil, fmt.Errorf("unknown dc_id: %d", dc.ID)
+		return nil, fmt.Errorf("%w: %d", ErrUnknownDC, dc.ID)
 	}
 	sess, err := session.NewSession(dc, st, c.config().Device.DeviceModel, c.config().Device.AppVersion, c.config().Device.SystemLangCode, c.config().Device.LangCode)
 	if err != nil {
@@ -2434,7 +2434,7 @@ func (c *Client) resolveBotUserAccessHash(ctx context.Context, userID int64) (tg
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: get user %d: %v", ErrPeerNotFound, userID, err)
+		return nil, fmt.Errorf("%w: get user %d: %w", ErrPeerNotFound, userID, err)
 	}
 	users := usersFromUsersGetUsers(result)
 	c.cachePeersFromUpdates(users, nil)
@@ -2457,7 +2457,7 @@ func (c *Client) resolveBotChannelAccessHash(ctx context.Context, channelID int6
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("%w: get channel %d: %v", ErrPeerNotFound, channelID, err)
+		return nil, fmt.Errorf("%w: get channel %d: %w", ErrPeerNotFound, channelID, err)
 	}
 	chats := chatsFromChatsClass(result)
 	c.cachePeersFromUpdates(nil, chats)
@@ -2662,7 +2662,7 @@ func (c *Client) GetSession(ctx context.Context, dcID int, isMedia bool, isCDN b
 
 	addr := ResolveDCAddress(dcID, c.config().TestMode)
 	if addr == "" {
-		return nil, fmt.Errorf("unknown dc_id: %d", dcID)
+		return nil, fmt.Errorf("%w: %d", ErrUnknownDC, dcID)
 	}
 	port := DefaultDCPort(c.config().TestMode)
 

--- a/telegram/dc_sessions.go
+++ b/telegram/dc_sessions.go
@@ -322,7 +322,7 @@ func (c *Client) createDCSession(ctx context.Context, dcID int) (*dcSessionEntry
 	}
 	addr := dc.Address()
 	if addr == "" {
-		return nil, fmt.Errorf("download: unknown dc_id: %d", dcID)
+		return nil, fmt.Errorf("download: %w: %d", ErrUnknownDC, dcID)
 	}
 	port := dc.Port()
 

--- a/telegram/errors.go
+++ b/telegram/errors.go
@@ -205,6 +205,15 @@ var (
 	// ErrNoSecretChats is returned when trying to accept or read a secret chat
 	// but no pending secret chats are available.
 	ErrNoSecretChats = errors.New("telegram: no pending secret chats")
+	// ErrSecretChatNotFound is returned when a secret chat with the given ID
+	// does not exist in the client's secret chat manager.
+	ErrSecretChatNotFound = errors.New("telegram: secret chat not found")
+	// ErrSecretChatNotReady is returned when a secret chat is not in the ready
+	// state for sending or receiving messages.
+	ErrSecretChatNotReady = errors.New("telegram: secret chat not ready")
+	// ErrSecretChatNoAuthKey is returned when a secret chat has not completed
+	// the key exchange.
+	ErrSecretChatNoAuthKey = errors.New("telegram: secret chat has no auth key")
 	// ErrBusinessConnIDRequired is returned when a business connection operation
 	// is attempted without providing the required connection ID.
 	ErrBusinessConnIDRequired = errors.New("business: connection id is required")
@@ -263,6 +272,23 @@ var (
 	// ErrJoinRequiresInvite is returned when attempting to join a chat without
 	// providing either a username or an invite hash.
 	ErrJoinRequiresInvite = errors.New("join requires a username or invite hash")
+)
+
+// Folder and DC routing errors.
+var (
+	// ErrFolderNotFound is returned when a dialog filter with the given ID
+	// cannot be found in the user's folder list.
+	ErrFolderNotFound = errors.New("folder not found")
+	// ErrUnknownDC is returned when a DC ID does not match any known data center
+	// configuration.
+	ErrUnknownDC = errors.New("unknown dc_id")
+)
+
+// Broadcast stream state errors.
+var (
+	// ErrStreamNotPlaying is returned when a pause, mute, or unmute operation
+	// is attempted on a stream that is not in the playing state.
+	ErrStreamNotPlaying = errors.New("stream is not playing")
 )
 
 // Context message operation errors.

--- a/telegram/ffmpeg_pipe.go
+++ b/telegram/ffmpeg_pipe.go
@@ -29,7 +29,7 @@ func (s *BroadcastStream) FeedChunk(data []byte) error {
 	s.mu.Lock()
 	if s.state != BroadcastPlaying {
 		s.mu.Unlock()
-		return fmt.Errorf("feed chunk: stream is %s", s.state)
+		return fmt.Errorf("feed chunk: %w: %s", ErrStreamNotPlaying, s.state)
 	}
 	if s.stdin == nil {
 		s.mu.Unlock()
@@ -48,7 +48,7 @@ func (s *BroadcastStream) FeedReader(r io.Reader) error {
 	s.mu.Lock()
 	if s.state != BroadcastPlaying {
 		s.mu.Unlock()
-		return fmt.Errorf("feed reader: stream is %s", s.state)
+		return fmt.Errorf("feed reader: %w: %s", ErrStreamNotPlaying, s.state)
 	}
 	if s.stdin == nil {
 		s.mu.Unlock()

--- a/telegram/live_broadcast.go
+++ b/telegram/live_broadcast.go
@@ -346,7 +346,7 @@ func (s *BroadcastStream) Pause() error {
 	s.mu.Lock()
 	if s.state != BroadcastPlaying {
 		s.mu.Unlock()
-		return fmt.Errorf("pause: stream is %s", s.state)
+		return fmt.Errorf("%w: %s", ErrStreamNotPlaying, s.state)
 	}
 
 	s.src.pausedAt = time.Since(s.src.startTime) + s.src.seekPos
@@ -423,7 +423,7 @@ func (s *BroadcastStream) Mute() error {
 	}
 	if s.state != BroadcastPlaying {
 		s.mu.Unlock()
-		return fmt.Errorf("mute: stream is %s", s.state)
+		return fmt.Errorf("%w: %s", ErrStreamNotPlaying, s.state)
 	}
 
 	s.src.muted = true
@@ -452,7 +452,7 @@ func (s *BroadcastStream) Unmute() error {
 	}
 	if s.state != BroadcastPlaying {
 		s.mu.Unlock()
-		return fmt.Errorf("unmute: stream is %s", s.state)
+		return fmt.Errorf("%w: %s", ErrStreamNotPlaying, s.state)
 	}
 
 	s.src.muted = false

--- a/telegram/reconnect.go
+++ b/telegram/reconnect.go
@@ -199,7 +199,7 @@ func (c *Client) reconnectOnce() error {
 		IPv6:     c.config().IPv6,
 	}
 	if dc.Address() == "" {
-		return fmt.Errorf("unknown dc_id: %d", dcID)
+		return fmt.Errorf("%w: %d", ErrUnknownDC, dcID)
 	}
 
 	sess, err := session.NewSession(dc, st, c.config().Device.DeviceModel, c.config().Device.AppVersion, c.config().Device.SystemLangCode, c.config().Device.LangCode)

--- a/telegram/resolve_peer.go
+++ b/telegram/resolve_peer.go
@@ -235,12 +235,12 @@ func (c *Client) ResolvePhone(ctx context.Context, phone string) (tg.InputPeerCl
 			Phone: phone,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("%w: resolve phone %s: %v", ErrPeerNotFound, phone, err)
+			return nil, fmt.Errorf("%w: resolve phone %s: %w", ErrPeerNotFound, phone, err)
 		}
 		c.resolveAndCache(result)
 		inputPeer, err := PeerToInputPeer(result.Peer, result.Users, result.Chats)
 		if err != nil {
-			return nil, fmt.Errorf("%w: phone %s: %v", ErrPeerNotFound, phone, err)
+			return nil, fmt.Errorf("%w: phone %s: %w", ErrPeerNotFound, phone, err)
 		}
 		return inputPeer, nil
 	})
@@ -294,12 +294,12 @@ func (c *Client) ResolveUsername(ctx context.Context, username string) (tg.Input
 			Username: username,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("%w: resolve @%s: %v", ErrPeerNotFound, username, err)
+			return nil, fmt.Errorf("%w: resolve @%s: %w", ErrPeerNotFound, username, err)
 		}
 		c.resolveAndCache(result)
 		inputPeer, err := PeerToInputPeer(result.Peer, result.Users, result.Chats)
 		if err != nil {
-			return nil, fmt.Errorf("%w: @%s: %v", ErrPeerNotFound, username, err)
+			return nil, fmt.Errorf("%w: @%s: %w", ErrPeerNotFound, username, err)
 		}
 		return inputPeer, nil
 	})

--- a/telegram/secret.go
+++ b/telegram/secret.go
@@ -117,7 +117,7 @@ func (c *Client) AcceptSecretChat(ctx context.Context, chatID int32) (*SecretCha
 
 	chat, ok := c.secretChats.Get(chatID)
 	if !ok {
-		return nil, fmt.Errorf("telegram: secret chat %d not found", chatID)
+		return nil, fmt.Errorf("%w: %d", ErrSecretChatNotFound, chatID)
 	}
 	if chat.GetState() != SecretChatStateWaiting {
 		return nil, fmt.Errorf("telegram: secret chat %d not in waiting state", chatID)
@@ -193,10 +193,10 @@ func (c *Client) SendSecretMessage(ctx context.Context, chatID int32, text strin
 	}
 	chat, ok := c.secretChats.Get(chatID)
 	if !ok {
-		return 0, fmt.Errorf("telegram: secret chat %d not found", chatID)
+		return 0, fmt.Errorf("%w: %d", ErrSecretChatNotFound, chatID)
 	}
 	if chat.GetState() != SecretChatStateReady {
-		return 0, fmt.Errorf("telegram: secret chat %d not ready", chatID)
+		return 0, fmt.Errorf("%w: %d", ErrSecretChatNotReady, chatID)
 	}
 
 	outSeq := chat.NextOutSeqNo()
@@ -292,10 +292,10 @@ func (c *Client) DecryptSecretMessage(chatID int32, ciphertext []byte) (*e2e.Dec
 	}
 	chat, ok := c.secretChats.Get(chatID)
 	if !ok {
-		return nil, fmt.Errorf("telegram: secret chat %d not found", chatID)
+		return nil, fmt.Errorf("%w: %d", ErrSecretChatNotFound, chatID)
 	}
 	if chat.AuthKey == nil {
-		return nil, fmt.Errorf("telegram: secret chat %d has no auth key", chatID)
+		return nil, fmt.Errorf("%w: %d", ErrSecretChatNoAuthKey, chatID)
 	}
 
 	plaintext, err := crypto.SecretDecrypt(ciphertext, chat.AuthKey, false)
@@ -593,10 +593,10 @@ func (c *Client) SendLayerNotification(ctx context.Context, chatID int32) error 
 	}
 	chat, ok := c.secretChats.Get(chatID)
 	if !ok {
-		return fmt.Errorf("telegram: secret chat %d not found", chatID)
+		return fmt.Errorf("%w: %d", ErrSecretChatNotFound, chatID)
 	}
 	if chat.GetState() != SecretChatStateReady {
-		return fmt.Errorf("telegram: secret chat %d not ready", chatID)
+		return fmt.Errorf("%w: %d", ErrSecretChatNotReady, chatID)
 	}
 
 	outSeq := chat.NextOutSeqNo()
@@ -668,10 +668,10 @@ func (c *Client) SendSecretFile(ctx context.Context, chatID int32, reader io.Rea
 
 	chat, ok := c.secretChats.Get(chatID)
 	if !ok {
-		return fmt.Errorf("telegram: secret chat %d not found", chatID)
+		return fmt.Errorf("%w: %d", ErrSecretChatNotFound, chatID)
 	}
 	if chat.GetState() != SecretChatStateReady {
-		return fmt.Errorf("telegram: secret chat %d not ready", chatID)
+		return fmt.Errorf("%w: %d", ErrSecretChatNotReady, chatID)
 	}
 
 	fileData, err := io.ReadAll(reader)

--- a/telegram/update_manager.go
+++ b/telegram/update_manager.go
@@ -408,7 +408,7 @@ func (m *updateManager) dispatchUpdate(upd *Update, meta updateMeta) error {
 		}
 	}
 
-	return fmt.Errorf("%w: %v", ErrUpdateHandlerFailed, lastErr)
+	return fmt.Errorf("%w: %w", ErrUpdateHandlerFailed, lastErr)
 }
 
 func (m *updateManager) replayDurableQueue() error {

--- a/telegram/update_recovery.go
+++ b/telegram/update_recovery.go
@@ -38,7 +38,7 @@ func (m *updateManager) RecoverAccount(ctx context.Context, rpc differenceRPC) e
 		m.mu.Unlock()
 		diff, err := rpc.UpdatesGetDifference(ctx, req)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrDifferenceRecovery, err)
+			return fmt.Errorf("%w: %w", ErrDifferenceRecovery, err)
 		}
 		done, err := m.applyDifference(ctx, diff)
 		if err != nil {
@@ -179,7 +179,7 @@ func (m *updateManager) RecoverChannel(ctx context.Context, rpc differenceRPC, c
 		}
 		result, err := rpc.UpdatesGetChannelDifference(ctx, req)
 		if err != nil {
-			return fmt.Errorf("%w: %v", ErrChannelDifference, err)
+			return fmt.Errorf("%w: %w", ErrChannelDifference, err)
 		}
 
 		done, err := m.applyChannelDifference(ctx, result, channelID)

--- a/telegram/webapp.go
+++ b/telegram/webapp.go
@@ -59,7 +59,7 @@ func ParseWebAppData(secretKey []byte, initData string, maxAge time.Duration) (*
 
 	vals, err := url.ParseQuery(initData)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %v", types.ErrWebAppDataInvalid, err)
+		return nil, fmt.Errorf("%w: %w", types.ErrWebAppDataInvalid, err)
 	}
 
 	raw := make(map[string]string, len(vals))
@@ -78,7 +78,7 @@ func ParseWebAppData(secretKey []byte, initData string, maxAge time.Duration) (*
 
 	authDateUnix, err := strconv.ParseInt(authDateStr, 10, 64)
 	if err != nil {
-		return nil, fmt.Errorf("%w: invalid auth_date: %v", types.ErrWebAppDataInvalid, err)
+		return nil, fmt.Errorf("%w: invalid auth_date: %w", types.ErrWebAppDataInvalid, err)
 	}
 	authDate := time.Unix(authDateUnix, 0)
 
@@ -122,7 +122,7 @@ func ParseWebAppData(secretKey []byte, initData string, maxAge time.Duration) (*
 
 	if userJSON, ok := raw["user"]; ok && userJSON != "" {
 		if err := json.Unmarshal([]byte(userJSON), &result.User); err != nil {
-			return nil, fmt.Errorf("%w: invalid user JSON: %v", types.ErrWebAppDataInvalid, err)
+			return nil, fmt.Errorf("%w: invalid user JSON: %w", types.ErrWebAppDataInvalid, err)
 		}
 	}
 

--- a/tg/message.go
+++ b/tg/message.go
@@ -2,8 +2,13 @@ package tg
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 )
+
+// errMessageBodyTooLarge is returned when a decoded MTProto message body exceeds
+// the maximum allowed size (1 MiB).
+var errMessageBodyTooLarge = errors.New("message body too large")
 
 const MTProtoMessageID = 0x5BB8E511
 
@@ -42,7 +47,7 @@ func DecodeMTProtoMessage(r *Reader) (*MTProtoMessage, error) {
 		return nil, err
 	}
 	if length > 1<<20 {
-		return nil, fmt.Errorf("message body too large: %d bytes", length)
+		return nil, fmt.Errorf("%w: %d bytes", errMessageBodyTooLarge, length)
 	}
 	bodyData, err := r.ReadRawBytes(int(length))
 	if err != nil {
@@ -83,7 +88,7 @@ func DecodeMTProtoMessageRaw(r *Reader) (*MTProtoMessageRaw, error) {
 		return nil, err
 	}
 	if length > 1<<20 {
-		return nil, fmt.Errorf("message body too large: %d bytes", length)
+		return nil, fmt.Errorf("%w: %d bytes", errMessageBodyTooLarge, length)
 	}
 	bodyData, err := r.ReadRawBytes(int(length))
 	if err != nil {


### PR DESCRIPTION
…repeated patterns

- Fix 12 instances of %v → %w in fmt.Errorf to preserve error chains for errors.Is/errors.As inspection (webapp, resolve_peer, update_recovery, update_manager, client)
- Add sentinel errors: ErrSecretChatNotFound, ErrSecretChatNotReady, ErrSecretChatNoAuthKey, ErrFolderNotFound, ErrUnknownDC, ErrStreamNotPlaying, errMessageBodyTooLarge, errPayloadTooShort
- Replace 22 repeated fmt.Errorf strings with sentinel-wrapped errors across secret.go, bound_folders.go, client.go, reconnect.go, dc_sessions.go, live_broadcast.go, ffmpeg_pipe.go, tg/message.go, session/{mtcute,telethon,gramjs,session}.go