### PR TITLE
fix(session): force-reset clock backward on bad_msg code 17

### DIFF
--- a/internal/session/msg_factory.go
+++ b/internal/session/msg_factory.go
@@ -35,3 +35,9 @@ func (f *MsgFactory) AllocateSeqNo(contentRelated bool) int32 {
 func (f *MsgFactory) UpdateServerTime(t time.Time) {
 	f.msgIDGen.UpdateServerTime(t)
 }
+
+// ForceResetServerTime forwards a forced (possibly backward) server-time reset
+// to the underlying message ID generator. See MsgIDGenerator.ForceResetServerTime.
+func (f *MsgFactory) ForceResetServerTime(t time.Time) {
+	f.msgIDGen.ForceResetServerTime(t)
+}

--- a/internal/session/msg_id.go
+++ b/internal/session/msg_id.go
@@ -37,6 +37,17 @@ func (g *MsgIDGenerator) UpdateServerTime(t time.Time) {
 	}
 }
 
+// ForceResetServerTime sets the internal clock to t unconditionally and resets
+// the counter, even when t is older than the current reference. This is used to
+// correct bad_msg_notification code 17 (msg_id too high), where the client's
+// clock has drifted ahead of the server and must move backward. UpdateServerTime
+// is forward-only and would no-op in that case. The server tolerates the
+// non-monotonic jump because it explicitly flagged the drift.
+func (g *MsgIDGenerator) ForceResetServerTime(t time.Time) {
+	g.serverTimeUnix.Store(t.Unix())
+	g.counter.Store(0)
+}
+
 // Next returns the next unique message ID, guaranteed to be monotonically
 // increasing. The lower bits encode a counter to ensure uniqueness within the
 // same second.

--- a/internal/session/msg_id_test.go
+++ b/internal/session/msg_id_test.go
@@ -66,3 +66,25 @@ func TestMsgIDGeneratorUpdateServerTime(t *testing.T) {
 		t.Errorf("msg_id=%d less than expected base after update=%d", id, expectedBase)
 	}
 }
+
+func TestMsgIDGeneratorUpdateServerTimeIgnoresOlder(t *testing.T) {
+	gen := NewMsgIDGenerator(time.Unix(1800000000, 0))
+	// An older time must be ignored to preserve monotonicity.
+	gen.UpdateServerTime(time.Unix(1700000000, 0))
+	id := gen.Next()
+	if id>>32 != 1800000000 {
+		t.Errorf("older time not ignored: msg_id base=%d, want 1800000000", id>>32)
+	}
+}
+
+func TestMsgIDGeneratorForceResetServerTimeBackward(t *testing.T) {
+	gen := NewMsgIDGenerator(time.Unix(1800000000, 0))
+	_ = gen.Next()
+	// Force-reset to an older time (code-17 correction); counter resets so the
+	// next id is allocated in the new (lower) epoch.
+	gen.ForceResetServerTime(time.Unix(1700000000, 0))
+	id := gen.Next()
+	if id>>32 != 1700000000 {
+		t.Errorf("force reset did not move clock backward: msg_id base=%d, want 1700000000", id>>32)
+	}
+}

--- a/internal/session/pfs_time_test.go
+++ b/internal/session/pfs_time_test.go
@@ -62,11 +62,18 @@ func TestBadMsgNotificationCode16AdjustsTimeAndResolves(t *testing.T) {
 	}
 }
 
-func TestBadMsgNotificationCode17AdjustsTimeAndResolves(t *testing.T) {
+func TestBadMsgNotificationCode17ResetsClockBackwardAndResolves(t *testing.T) {
 	s := newSessionWithAuthKey(t)
 
-	futureTime := time.Now().Add(2 * time.Hour)
-	badMsgID := futureTime.Unix() << 32
+	// Client clock has drifted 1h ahead of the server.
+	drifted := time.Now().Add(time.Hour)
+	s.msgFactory.UpdateServerTime(drifted)
+
+	// The server responds with code 17. Its notification msg_id carries the
+	// authoritative (lower) server time, well behind our drifted clock.
+	serverTime := drifted.Add(-2 * time.Hour)
+	notifMsgID := serverTime.Unix() << 32
+	badMsgID := drifted.Unix() << 32 // the too-high msg_id we sent
 
 	h, err := s.pending.Register(badMsgID, false)
 	if err != nil {
@@ -74,7 +81,7 @@ func TestBadMsgNotificationCode17AdjustsTimeAndResolves(t *testing.T) {
 	}
 
 	body := encodeBadMsgNotification(badMsgID, 0, 17)
-	if !s.handleRawPacket(badMsgID, body) {
+	if !s.handleRawPacket(notifMsgID, body) {
 		t.Fatal("handleRawPacket returned false, want true")
 	}
 
@@ -94,11 +101,12 @@ func TestBadMsgNotificationCode17AdjustsTimeAndResolves(t *testing.T) {
 		t.Fatalf("bad msg id: got %d, want %d", bad.BadMsgID, badMsgID)
 	}
 
-	// Verify server time was updated (forward, so UpdateServerTime advances).
-	newMsgID := s.msgFactory.AllocateMsgID()
-	serverTime := newMsgID >> 32
-	if serverTime < futureTime.Unix() {
-		t.Fatalf("server time not advanced: got %d, want >= %d", serverTime, futureTime.Unix())
+	// The clock must have moved BACKWARD to the server's time. Without the
+	// force-reset, UpdateServerTime no-ops and the clock stays drifted, so the
+	// retry would resend the same too-high msg_id until exhaustion.
+	got := s.msgFactory.AllocateMsgID() >> 32
+	if got > serverTime.Unix()+5 {
+		t.Fatalf("code 17 did not reset clock backward: got=%d, want~=%d", got, serverTime.Unix())
 	}
 }
 

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -1675,12 +1675,18 @@ func (s *Session) handleRawPacket(msgID int64, body []byte) bool {
 			// client/server clock drift. The server's current time is encoded
 			// in the upper 32 bits of the notification's msg_id (msgID parameter).
 			serverTime := msgID >> 32
-			s.msgFactory.UpdateServerTime(time.Unix(serverTime, 0))
+			if errorCode == 16 {
+				// Client clock is behind the server: advance forward.
+				s.msgFactory.UpdateServerTime(time.Unix(serverTime, 0))
+			} else {
+				// Code 17: client clock is ahead of the server. UpdateServerTime
+				// is forward-only and would no-op here, so the retry would resend
+				// the same too-high msg_id until retries exhaust. Force the clock
+				// backward to the server's authoritative time.
+				s.msgFactory.ForceResetServerTime(time.Unix(serverTime, 0))
+			}
 			if s.log != nil {
 				s.log.Warnf("session: time corrected (code=%d) server_time=%d", errorCode, serverTime)
-			}
-			if errorCode == 17 && s.log != nil {
-				s.log.Warnf("session: msg_id too high (code=17), reconnect recommended to reset session")
 			}
 			// Resolve with BadMsgNotification so Invoke's retry loop
 			// re-sends the query with the corrected time (via a fresh


### PR DESCRIPTION
## Problem

`bad_msg_notification` **code 17** (msg_id too high) means the client's clock is *ahead* of the server, so the correction must move the msg_id time **backward**. But `MsgIDGenerator.UpdateServerTime` is forward-only — it ignores older times to preserve monotonicity (`if newUnix <= cur { return }`). So the code-17 correction was a **silent no-op**.

Commit a1c655b changed codes 16/17 from `Reject` to `Resolve`, intending `Invoke`'s retry loop to resend with a corrected msg_id. That works for **code 16** (forward correction succeeds), but for **code 17** the clock never moved, so every retry resent the same too-high msg_id and the RPC failed after exhausting retries.

The existing code-17 test did not catch this: it reused the future-time bad msg_id as the notification's own msg_id (a forward move), so it never exercised backward correction.

## Fix

- Add `MsgIDGenerator.ForceResetServerTime(t)` — unconditional set + counter reset, for code-17 backward correction. The server tolerates the non-monotonic jump because it explicitly flagged the drift.
- Route code 17 through `ForceResetServerTime`; code 16 keeps the monotonic forward path (`UpdateServerTime`).

## Validation

- New realistic code-17 regression test (`TestBadMsgNotificationCode17ResetsClockBackwardAndResolves`) — **fails on the pre-fix code**, passes after.
- Unit tests: `ForceResetServerTime` backward reset; `UpdateServerTime` ignores older times.
- `go test -race ./internal/session/` — pass.
- `go test ./...` — 16 packages, 0 failures.
- `go vet ./...`, `gofmt` on changed files — clean.

## Files

- `internal/session/msg_id.go`, `msg_factory.go` — new `ForceResetServerTime`.
- `internal/session/session.go` — split code 16 (forward) / 17 (force-backward).
- `internal/session/pfs_time_test.go`, `msg_id_test.go` — tests.