### PR TITLE
fix: handle non-object TL results (Bool, string) in encodeResultToJSON

### DIFF
--- a/telegram/json_client.go
+++ b/telegram/json_client.go
@@ -258,9 +258,12 @@ func encodeResultToJSON(obj tg.TLObject, useSnakeCase bool) ([]byte, error) {
 		return nil, fmt.Errorf("telegram: marshal result: %w", err)
 	}
 
+	// Non-object results (e.g. BoolTrue/BoolFalse → JSON true/false) cannot
+	// be unmarshaled into a map. Return the marshaled data directly — there
+	// are no keys to convert or constructor tag to inject.
 	var raw map[string]any
 	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("telegram: unmarshal result: %w", err)
+		return data, nil
 	}
 
 	tlName, hasName := getIDToName()[obj.ConstructorID()]


### PR DESCRIPTION
## Problem

`encodeResultToJSON` assumes every TLObject result marshals to a JSON object (`map[string]any`). But some Telegram methods return `BoolTrue`/`BoolFalse`, which marshal to JSON `true`/`false`. This causes:

```
telegram: unmarshal result: json: cannot unmarshal bool into Go value of type map[string]interface {}
```

Affected methods include `account.deleteAccount`, `account.updateStatus`, `messages.setTyping`, `account.checkUsername`, and any other method returning `Bool`.

## Fix

When `json.Unmarshal(data, &raw)` fails (because the result is a primitive — bool, string, number), return the marshaled data directly. Primitive results have no keys to convert or constructor tag (`_`) to inject, so the map-based processing is unnecessary.

```go
var raw map[string]any
if err := json.Unmarshal(data, &raw); err != nil {
    return data, nil
}
```

## Reproduction

```go
jc := telegram.NewJSONClient(rpc)
_, err := jc.InvokeJSON(ctx, "account.deleteAccount", []byte(`{"reason":"test"}`), false)
// err: telegram: unmarshal result: json: cannot unmarshal bool into Go value of type map[string]interface {}
```

After fix: returns `true` (the JSON serialization of BoolTrue).