### PR TITLE
fix(session,telegram): scalability and stability fixes

### DIFF
--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -300,9 +300,10 @@ func (s *Session) ResetWriteBreaker() {
 	s.writeBreakerOpen.Store(false)
 }
 
-// trackWriteResult updates the write circuit breaker. Consecutive failures open the
-// breaker, which blocks new writes via ErrWriteCircuitOpen but does NOT kill the
-// session. Successful writes reset both counter and breaker flag.
+// trackWriteResult updates the write circuit breaker. After threshold
+// consecutive failures the breaker opens and the errgroup is cancelled to
+// trigger immediate session shutdown + reconnect (fail-fast). Successful
+// writes reset both counter and breaker flag.
 func (s *Session) trackWriteResult(err error) {
 	threshold := int(s.writeBreakerThreshold.Load())
 	if threshold <= 0 {
@@ -312,6 +313,15 @@ func (s *Session) trackWriteResult(err error) {
 		newCount := s.consecWriteFailures.Add(1)
 		if int(newCount) >= threshold && !s.writeBreakerOpen.Load() {
 			s.writeBreakerOpen.Store(true)
+			if s.log != nil {
+				s.log.Errorf("session: write circuit breaker tripped after %d consecutive failures, forcing reconnect", newCount)
+			}
+			// Fail-fast: cancel the errgroup to trigger immediate session
+			// shutdown + reconnect via handleClose, rather than lingering
+			// until the read deadline expires (~60-120s).
+			if s.group != nil {
+				s.group.Cancel()
+			}
 		}
 	} else {
 		s.consecWriteFailures.Store(0)
@@ -1117,7 +1127,9 @@ func (s *Session) runLoop(ctx context.Context) error {
 	g.Go(s.pingLoop)
 	g.Go(s.saltLoop)
 	g.Go(s.handleClose)
-	g.Go(s.pfsRenewalLoop)
+	if pfs := s.PFS(); pfs != nil && pfs.IsEnabled() {
+		g.Go(s.pfsRenewalLoop)
+	}
 
 	err := g.Wait()
 	s.sm.transitionTo(StateClosed)
@@ -1225,10 +1237,10 @@ func (s *Session) storeFutureSalts(fs *tg.FutureSalts) {
 	s.saltMgr.StoreFromFutureSalts(saltEntriesFromFuture(fs.Salts))
 }
 
-func (s *Session) sendServiceMessage(body tg.TLObject) {
+func (s *Session) sendServiceMessage(body tg.TLObject) error {
 	select {
 	case <-s.done:
-		return
+		return ErrSessionClosed
 	default:
 	}
 	s.mu.RLock()
@@ -1247,9 +1259,15 @@ func (s *Session) sendServiceMessage(body tg.TLObject) {
 		if s.log != nil {
 			s.log.Errorf("session: pack service message: %v", err)
 		}
-		return
+		return fmt.Errorf("session: pack service message: %w", err)
 	}
-	_ = s.writeEncryptedDirect(encrypted, 10*time.Second)
+	if err := s.writeEncryptedDirect(encrypted, 10*time.Second); err != nil {
+		if s.log != nil {
+			s.log.Warnf("session: service message write failed (%T): %v", body, err)
+		}
+		return err
+	}
+	return nil
 }
 
 // writeEncryptedImpl is the shared implementation for writeEncrypted and
@@ -1448,10 +1466,12 @@ func (s *Session) pingLoop(ctx context.Context) error {
 		s.pingCbs[pingID] = pongCh
 		s.pingMux.Unlock()
 
-		s.sendServiceMessage(&tg.PingDelayDisconnectRequest{
-			PingID:          pingID,
-			DisconnectDelay: int32(delay.Seconds()),
-		})
+	if err := s.sendServiceMessage(&tg.PingDelayDisconnectRequest{
+		PingID:          pingID,
+		DisconnectDelay: int32(delay.Seconds()),
+	}); err != nil {
+		return fmt.Errorf("session: ping write failed: %w", err)
+	}
 
 		select {
 		case <-ctx.Done():
@@ -1488,7 +1508,7 @@ func (s *Session) ackLoop(ctx context.Context) error {
 		batch := make([]int64, len(buf))
 		copy(batch, buf)
 		buf = buf[:0]
-		s.sendServiceMessage(&tg.MsgsAck{MsgIds: batch})
+		_ = s.sendServiceMessage(&tg.MsgsAck{MsgIds: batch})
 	}
 
 	for {
@@ -1510,10 +1530,13 @@ func (s *Session) ackLoop(ctx context.Context) error {
 // saltLoop is an errgroup goroutine that periodically requests future salts
 // from the server.
 func (s *Session) saltLoop(ctx context.Context) error {
+	timer := time.NewTimer(initialSaltFetchWait)
+	defer timer.Stop()
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case <-time.After(initialSaltFetchWait):
+	case <-timer.C:
 	}
 
 	s.fetchSaltsWithRetry(ctx)
@@ -1524,10 +1547,11 @@ func (s *Session) saltLoop(ctx context.Context) error {
 			wait = defaultSaltRefreshMin
 		}
 
+		timer.Reset(wait)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(wait):
+		case <-timer.C:
 			s.fetchSaltsWithRetry(ctx)
 		}
 	}

--- a/internal/session/session_test.go
+++ b/internal/session/session_test.go
@@ -1917,7 +1917,7 @@ func TestCompletedCallsFreePendingCapacity(t *testing.T) {
 	}
 }
 
-func TestWriteBreakerBlocksWritesButKeepsSessionAlive(t *testing.T) {
+func TestWriteBreakerTrippedCancelsErrgroup(t *testing.T) {
 	s := newSessionWithAuthKey(t)
 	ft := newFailingTransport()
 	s.SetTransport(ft)
@@ -1950,14 +1950,15 @@ func TestWriteBreakerBlocksWritesButKeepsSessionAlive(t *testing.T) {
 		t.Fatal("breaker should be open")
 	}
 
-	// The group context should NOT be cancelled — the session stays alive.
+	// Fail-fast: the errgroup context should be cancelled to trigger
+	// immediate session shutdown + reconnect.
 	select {
 	case <-g.ctx.Done():
-		t.Fatal("group context should NOT be cancelled when breaker opens")
-	case <-time.After(100 * time.Millisecond):
+	case <-time.After(time.Second):
+		t.Fatal("errgroup context should be cancelled when breaker opens (fail-fast)")
 	}
 
-	// Subsequent writes should get ErrWriteCircuitOpen.
+	// Subsequent writes should still get ErrWriteCircuitOpen.
 	err = s.writeEncryptedDirect(make([]byte, 10), time.Second)
 	if !errors.Is(err, ErrWriteCircuitOpen) {
 		t.Fatalf("expected ErrWriteCircuitOpen, got %v", err)

--- a/telegram/compose.go
+++ b/telegram/compose.go
@@ -7,25 +7,18 @@ import (
 
 var (
 	globalClientsMu sync.Mutex
-	globalClients   []*Client
+	globalClients   = make(map[*Client]struct{})
 )
 
 func registerClient(c *Client) {
 	globalClientsMu.Lock()
-	globalClients = append(globalClients, c)
+	globalClients[c] = struct{}{}
 	globalClientsMu.Unlock()
 }
 
 func unregisterClient(c *Client) {
 	globalClientsMu.Lock()
-	for i, cl := range globalClients {
-		if cl == c {
-			globalClients[i] = globalClients[len(globalClients)-1]
-			globalClients[len(globalClients)-1] = nil
-			globalClients = globalClients[:len(globalClients)-1]
-			break
-		}
-	}
+	delete(globalClients, c)
 	globalClientsMu.Unlock()
 }
 
@@ -42,8 +35,10 @@ func unregisterClient(c *Client) {
 //	telegram.Idle()
 func Idle() {
 	globalClientsMu.Lock()
-	clients := make([]*Client, len(globalClients))
-	copy(clients, globalClients)
+	clients := make([]*Client, 0, len(globalClients))
+	for c := range globalClients {
+		clients = append(clients, c)
+	}
 	globalClientsMu.Unlock()
 
 	var wg sync.WaitGroup

--- a/telegram/reconnect.go
+++ b/telegram/reconnect.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	mrand "math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -51,6 +52,11 @@ func (c backoffConfig) delay(attempt int) time.Duration {
 	delay := float64(c.BaseDelay) * math.Pow(c.Multiplier, float64(attempt))
 	if delay > float64(c.MaxDelay) {
 		delay = float64(c.MaxDelay)
+	}
+	// Apply jitter: randomize within [1-Jitter, 1+Jitter) to desynchronize
+	// reconnect schedules across sessions after mass disconnect events.
+	if c.Jitter > 0 {
+		delay *= 1 + (mrand.Float64()*2-1)*c.Jitter
 	}
 	return time.Duration(delay)
 }
@@ -372,7 +378,10 @@ func (rm *reconnectManager) Attempts() int {
 }
 
 func (rm *reconnectManager) loop(ctx context.Context) {
-	defer close(rm.done)
+	defer func() {
+		rm.running.Store(false)
+		close(rm.done)
+	}()
 	timer := time.NewTimer(0)
 	if !timer.Stop() {
 		<-timer.C
@@ -390,7 +399,6 @@ func (rm *reconnectManager) loop(ctx context.Context) {
 				Attempts: attempt,
 				Err:      ErrReconnectFailed,
 			})
-			rm.running.Store(false)
 			rm.client.signalReconnect()
 			return
 		}
@@ -421,7 +429,6 @@ func (rm *reconnectManager) loop(ctx context.Context) {
 		err := rm.client.reconnectOnce()
 		if err == nil {
 			rm.client.Log.Info("reconnected successfully")
-			rm.running.Store(false)
 			return
 		}
 
@@ -431,7 +438,6 @@ func (rm *reconnectManager) loop(ctx context.Context) {
 				Attempts: attempt,
 				Err:      fmt.Errorf("auth key invalid: %w", err),
 			})
-			rm.running.Store(false)
 			rm.client.signalReconnect()
 			return
 		}

--- a/telegram/reconnect_health_test.go
+++ b/telegram/reconnect_health_test.go
@@ -180,7 +180,12 @@ func TestConnStateBackwardCompat(t *testing.T) {
 }
 
 func TestBackoffConfig(t *testing.T) {
-	cfg := defaultBackoffConfig
+	// Use a jitter-free config for deterministic delay checks.
+	cfg := backoffConfig{
+		BaseDelay:  1 * time.Second,
+		MaxDelay:   60 * time.Second,
+		Multiplier: 2.0,
+	}
 
 	if d := cfg.delay(0); d != cfg.BaseDelay {
 		t.Fatalf("delay(0) = %v, want %v", d, cfg.BaseDelay)
@@ -190,6 +195,16 @@ func TestBackoffConfig(t *testing.T) {
 	}
 	if d := cfg.delay(10); d != cfg.MaxDelay {
 		t.Fatalf("delay(10) = %v, want MaxDelay %v", d, cfg.MaxDelay)
+	}
+
+	// Verify jitter is applied when Jitter > 0.
+	jittered := defaultBackoffConfig // Jitter: 0.1
+	base := time.Duration(float64(jittered.BaseDelay) * jittered.Multiplier)
+	d := jittered.delay(1)
+	lo := time.Duration(float64(base) * (1 - jittered.Jitter))
+	hi := time.Duration(float64(base) * (1 + jittered.Jitter))
+	if d < lo || d > hi {
+		t.Fatalf("jittered delay(1) = %v, want within [%v, %v]", d, lo, hi)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes 7 scalability and stability bugs identified in the mtgo v0.15.3 scalability audit against the Telegram username checker workload (1–2,500+ concurrent `telegram.Client` instances).

All findings verified against current HEAD (`3752871`) before fixing. Report accuracy issue noted below.

## Changes

### Critical

| ID | File | Fix |
|---|---|---|
| **CRIT-1** | `telegram/reconnect.go` | `reconnectManager.loop()` now defers `rm.running.Store(false)` on **all** exit paths. Previously, the `!CanReconnect()` return left `running=true`, permanently disabling the background reconnector via the CAS gate in `Start()`. After the first disconnect where AutoConnect reconnected inline, no future background reconnect could launch. |
| **CRIT-2** | `telegram/compose.go` | `globalClients []*Client` → `map[*Client]struct{}`. O(1) register/unregister instead of O(N) linear scan under the global mutex. At 25K clients, mass shutdown drops from ~625M pointer comparisons to 25K map deletes. |
| **CRIT-3** | `internal/session/session.go` | `sendServiceMessage` now returns and logs write errors instead of discarding them with `_ =`. `pingLoop` fails fast on ping write failure (returns error → errgroup cancels → reconnect). Acks remain best-effort (`_ =`) since the server re-requests unacked messages. |
| **CRIT-4** | `internal/session/session.go` | `trackWriteResult` calls `s.group.Cancel()` when the write circuit breaker opens, triggering immediate session shutdown via `handleClose` (transport close → readLoop exit). Previously the breaker latched open with no reset path in production code; the session lingered 60–120s until the read deadline expired. |

### Trivial

| ID | File | Fix |
|---|---|---|
| **MED-3** | `internal/session/session.go` | `pfsRenewalLoop` only spawned when `s.PFS().IsEnabled()`. Eliminates an idle goroutine per session when PFS is off (default). |
| **MED-4** | `internal/session/session.go` | `saltLoop` uses `time.NewTimer` + `Reset` instead of `time.After`. Prevents stale timers (up to ~1.5h lifetime) from accumulating in the runtime timer heap. |
| **HIGH-5** | `telegram/reconnect.go` | `backoffConfig.delay()` now applies the `Jitter` field (default `0.1` = ±10%). The field existed but was never read — reconnect delays were pure exponential with no randomization, causing synchronized reconnect waves after mass disconnects. |

## Test updates

- `TestWriteBreakerBlocksWritesButKeepsSessionAlive` → renamed to `TestWriteBreakerTrippedCancelsErrgroup`; asserts the errgroup context **is** cancelled (fail-fast behavior from CRIT-4).
- `TestBackoffConfig` uses a jitter-free config for deterministic delay checks, plus a separate assertion verifying jitter is applied within `[1−Jitter, 1+Jitter]`.

## Report accuracy note

The audit report (~/dev/zaid/checker/MTGO_SCALABILITY_REPORT.md) cited HIGH-5's `defaultBackoffConfig.Jitter = 0.0` and quoted `delay()` using a `for` loop. **Actual source** had `Jitter: 0.1` and `math.Pow`. The substantive finding (jitter field unused in `delay()`) was correct, but the supporting evidence was wrong. All Critical findings verified at exact cited lines.

## Out of scope (not fixed in this PR)

HIGH-1 (ping jitter), HIGH-2 (ackFlushInterval), HIGH-3 (stateCheckLoop idle backoff), HIGH-4 (inline dispatch blocks pong), MED-1 (AES cipher caching), MED-2 (SHA-256 allocs), LOW-1/LOW-2 (transport allocs).