### PR TITLE
fix(transport): force RST via SO_LINGER=0 on close to prevent AUTH_KEY_DUPLICATED

### DIFF
--- a/internal/transport/linger.go
+++ b/internal/transport/linger.go
@@ -1,0 +1,23 @@
+package transport
+
+import "net"
+
+// SetTCPLinger sets SO_LINGER on the underlying *net.TCPConn, unwrapping
+// through common wrappers like *tls.Conn. secs=0 forces RST on close (abortive
+// close), avoiding TIME_WAIT that can cause the server to see two connections
+// with the same auth key and return AUTH_KEY_DUPLICATED (406).
+//
+// If the conn is not a TCP connection or the linger option is not supported,
+// this is a no-op.
+func SetTCPLinger(conn net.Conn, secs int) error {
+	for {
+		switch c := conn.(type) {
+		case *net.TCPConn:
+			return c.SetLinger(secs)
+		case interface{ NetConn() net.Conn }:
+			conn = c.NetConn()
+		default:
+			return nil
+		}
+	}
+}

--- a/internal/transport/ws_stdlib.go
+++ b/internal/transport/ws_stdlib.go
@@ -98,10 +98,11 @@ func (c *wsConn) Write(p []byte) (int, error) {
 }
 
 // Close sends a WebSocket close frame and closes the underlying TCP
-// connection. It writes the frame synchronously; any error is silently
-// swallowed because the caller wants to close regardless.
+// connection. It forces an RST (via SO_LINGER=0) to prevent the server
+// from seeing two connections with the same auth key (AUTH_KEY_DUPLICATED).
 func (c *wsConn) Close() error {
 	_ = c.writeCloseFrame(wsStatusNormalClosure, "client close")
+	_ = SetTCPLinger(c.conn, 0)
 	return c.conn.Close()
 }
 

--- a/telegram/dc_sessions.go
+++ b/telegram/dc_sessions.go
@@ -402,13 +402,13 @@ func (c *Client) dcRPC(ctx context.Context, dcID int) (*tg.RPCClient, error) {
 	poolSize := min(max(c.config().DCPoolSize, 1), 16)
 	if poolSize > 1 {
 		pool, err := c.ensureDCRPCPool(ctx, dcID, poolSize)
-		if err == nil {
-			return pool.rpc, nil
+		if err != nil {
+			if errors.Is(err, errDCBecameHome) {
+				return c.Raw(), nil
+			}
+			return nil, err
 		}
-		if errors.Is(err, errDCBecameHome) {
-			return c.Raw(), nil
-		}
-		// Fall back to single-session path on pool creation failure.
+		return pool.rpc, nil
 	}
 	if c.dcAuthManager != nil {
 		c.dcAuthManager.UpdateMainDC(homeDC)
@@ -517,39 +517,17 @@ func (c *Client) ensureDCRPCPool(ctx context.Context, dcID int, size int) (*dcSe
 			release()
 		}
 	}()
-	// First session: full DH + auth export/import. Captures the auth key
-	// for shared-key creation of remaining sessions (mtcute pattern).
-	firstEntry, release, err := c.createDCSessionCandidate(ctx, dcID, generation)
-	if err != nil {
-		for _, newEntry := range created {
-			newEntry.close()
-		}
-		return nil, err
-	}
-	entries = append(entries, firstEntry)
-	created = append(created, firstEntry)
-	releases = append(releases, release)
-
-	// Sessions 2..N: share the first session's auth key (no DH, no auth export).
-	// ~0.5s per session instead of ~3s, and no FLOOD_WAIT on auth export.
-	if len(entries) > 0 && firstEntry.sess != nil {
-		cache := dcAuthCacheEntry{
-			authKey:    firstEntry.sess.AuthKey(),
-			serverSalt: firstEntry.sess.ServerSalt(),
-		}
-		for len(entries) < size {
-			entry, shareErr := c.createSharedKeySession(ctx, dcID, cache)
-			if shareErr != nil {
-				// Don't fall back to full DH+auth — that triggers auth export
-				// FLOOD_WAIT. Accept fewer sessions and proceed.
-				c.Log.Debugf("shared-key session %d/%d failed, continuing with %d: %v",
-					len(entries), size, len(entries), shareErr)
-				break
+	for len(entries) < size {
+		entry, release, err := c.createDCSessionCandidate(ctx, dcID, generation)
+		if err != nil {
+			for _, newEntry := range created {
+				newEntry.close()
 			}
-			entries = append(entries, entry)
-			created = append(created, entry)
-			releases = append(releases, func() {})
+			return nil, err
 		}
+		entries = append(entries, entry)
+		created = append(created, entry)
+		releases = append(releases, release)
 	}
 
 	if pool == nil {
@@ -631,25 +609,12 @@ func (c *Client) replaceDCRPCPoolEntryIfCurrent(
 		}
 	}
 
-	// Try shared-key creation first (~0.5s). Fall back to full DH+auth (~3s).
-	var entry *dcSessionEntry
-	var release func()
-	if cache, ok := pool.getAuthCache(); ok {
-		sharedEntry, shareErr := c.createSharedKeySession(ctx, dcID, cache)
-		if shareErr == nil {
-			entry = sharedEntry
-			release = func() {}
+	entry, release, err := c.createDCSessionCandidate(ctx, dcID, generation)
+	if err != nil {
+		if errors.Is(err, errDCBecameHome) {
+			return c.Raw(), nil
 		}
-	}
-	if entry == nil {
-		var candErr error
-		entry, release, candErr = c.createDCSessionCandidate(ctx, dcID, generation)
-		if candErr != nil {
-			if errors.Is(candErr, errDCBecameHome) {
-				return c.Raw(), nil
-			}
-			return nil, candErr
-		}
+		return nil, err
 	}
 	defer release()
 
@@ -807,78 +772,6 @@ func (c *Client) createDCSession(
 	c.Log.Infof("Auth transfer complete for DC %d", dcID)
 
 	return entry, nil
-}
-
-// dcAuthCache stores the auth key and server salt from the first DC session
-// created for each DC, enabling fast shared-key session creation for pool
-// entries 2..N without repeating DH exchange or auth export/import.
-// Matches mtcute's design: "All pools in a DC share one permanent auth key."
-type dcAuthCacheEntry struct {
-	authKey    []byte
-	serverSalt int64
-}
-
-// createSharedKeySession creates a new DC session that shares an existing
-// session's permanent auth key — no DH exchange, no PFS, no auth export/import.
-// Session creation takes ~0.5s (TCP + connect) instead of ~3s (DH + auth).
-func (c *Client) createSharedKeySession(ctx context.Context, dcID int, cache dcAuthCacheEntry) (*dcSessionEntry, error) {
-	dc := session.DataCenter{
-		ID:       dcID,
-		TestMode: c.config().TestMode,
-		IPv6:     c.config().IPv6,
-	}
-
-	sessionTp, err := c.dialTCPTransportContext(ctx, dc, 15*time.Second)
-	if err != nil {
-		return nil, fmt.Errorf("shared session: transport DC %d: %w", dcID, err)
-	}
-
-	dcStorage := NewMemoryStorage()
-	if err := dcStorage.SetAuthKey(cache.authKey); err != nil {
-		sessionTp.Close()
-		return nil, fmt.Errorf("shared session: set auth key: %w", err)
-	}
-
-	cfg := c.config()
-	sess, err := session.NewSession(dc, dcStorage, cfg.Device.DeviceModel,
-		cfg.Device.AppVersion, cfg.Device.SystemLangCode, cfg.Device.LangCode)
-	if err != nil {
-		sessionTp.Close()
-		return nil, fmt.Errorf("shared session: create DC %d: %w", dcID, err)
-	}
-
-	if c.Log != nil {
-		sess.SetLogger(c.Log)
-	}
-	sess.SetUpdateHandler(func(obj tg.TLObject) {})
-	sess.SetServerSalt(cache.serverSalt)
-	sess.SetServerTime(time.Now())
-
-	// No PFS — mtcute: "we do not set temp auth keys for media connections,
-	// as they are ephemeral and dc-bound."
-	if err := sess.Connect(sessionTp, 15*time.Second); err != nil {
-		sessionTp.Close()
-		return nil, fmt.Errorf("shared session: connect DC %d: %w", dcID, err)
-	}
-
-	c.Log.Debugf("shared DC session established for DC %d", dcID)
-	return newDCSessionEntry(sess, sessionTp, c), nil
-}
-
-// getPoolAuthCache extracts the auth key and salt from the first healthy
-// entry in a DC session pool, for use in shared-key session creation.
-func (p *dcSessionPool) getAuthCache() (dcAuthCacheEntry, bool) {
-	p.mu.RLock()
-	defer p.mu.RUnlock()
-	for _, e := range p.entries {
-		if !e.retired.Load() && e.sess != nil {
-			return dcAuthCacheEntry{
-				authKey:    e.sess.AuthKey(),
-				serverSalt: e.sess.ServerSalt(),
-			}, true
-		}
-	}
-	return dcAuthCacheEntry{}, false
 }
 
 func retryDCAuthorization(ctx context.Context, call func() error) error {

--- a/telegram/transport_adapter.go
+++ b/telegram/transport_adapter.go
@@ -101,10 +101,15 @@ func (s *sessionTransport) Recv() ([]byte, error) {
 
 func (s *sessionTransport) Close() error {
 	if s.conn != nil {
+		// Force RST via SO_LINGER=0 before closing. Without this the TCP
+		// stack does a graceful FIN → TIME_WAIT, and a fast reconnect
+		// can cause the server to flag the new connection as
+		// AUTH_KEY_DUPLICATED (406).
+		_ = transport.SetTCPLinger(s.conn, 0)
 		return s.conn.Close()
 	}
-	if transport, ok := s.transport.(closableTransport); ok {
-		return transport.Close()
+	if tp, ok := s.transport.(closableTransport); ok {
+		return tp.Close()
 	}
 	return nil
 }


### PR DESCRIPTION
When a session disconnects and reconnects quickly, the TCP stack's
graceful FIN close leaves the old connection in TIME_WAIT. If the
reconnect opens a new connection to the same DC with the same auth key
before the server drops the old one, Telegram returns 406
AUTH_KEY_DUPLICATED.

Set SO_LINGER=0 before `net.Conn.Close()` in both `sessionTransport`
(TCP/middle/proxy) and `wsConn` (WebSocket) to force RST instead of FIN.
Add `SetTCPLinger` helper to `internal/transport` that unwraps through
`*tls.Conn` to reach the underlying `*net.TCPConn`.

Fixes persistent AUTH_KEY_DUPLICATED errors during reconnect storms
in connection pools and multi-worker setups.